### PR TITLE
Devel amll

### DIFF
--- a/TransportAPI/YANG/TapiDataTypes.yang
+++ b/TransportAPI/YANG/TapiDataTypes.yang
@@ -87,6 +87,9 @@ module TapiDataTypes {
       enum LEAF;
     }
   }
+  typedef UniversalId {
+      type string;
+  }
   
   grouping LayerProtocol {
     leaf layerProtocol {
@@ -105,14 +108,6 @@ module TapiDataTypes {
     }
   
   }  
-  
-  grouping UniversalId {
-  
-    leaf uuid {
-      type string;
-    }
-    
-  }
   
   /** 
    * PAC groupings

--- a/TransportAPI/YANG/TapiInformationModel.yang
+++ b/TransportAPI/YANG/TapiInformationModel.yang
@@ -63,7 +63,10 @@ module TapiInformationModel {
     In cases where there is resilience the LinkEnd may convey the resilience role of the access to the Link. 
     The Link can be considered as a component and the LinkEnd as a Port on that component";
     
-    uses TapiDt:UniversalId; // Missing in Tapi UML
+    
+    leaf uuid{
+    	type TapiDt:UniversalId;
+    }
     
     leaf-list _nodeEpRefList {
       type leafref {
@@ -95,7 +98,9 @@ module TapiInformationModel {
       At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). ";
     
 
-    uses TapiDt:UniversalId;
+    leaf uuid{
+    	type TapiDt:UniversalId; // Missing in Tapi UML
+    }
 
     leaf-list _encapTopologyRef {
       type leafref {
@@ -179,8 +184,9 @@ module TapiInformationModel {
     description
     "The Link object class models effective adjacency between two or more ForwardingDomains (FD).";
     
-
-    uses TapiDt:UniversalId;
+    leaf uuid{
+    	type TapiDt:UniversalId;
+    }
 
     list linkEndList {
       key "uuid";
@@ -265,9 +271,10 @@ module TapiInformationModel {
   }
   
   grouping Topology {
-
-    uses TapiDt:UniversalId;
-    
+  
+    leaf uuid{
+    	type TapiDt:UniversalId;
+    }
     
     list node {
       key "uuid";
@@ -309,9 +316,9 @@ module TapiInformationModel {
     termination and adaptation functions of one or more transport layers. 
     The structure of LTP supports all transport protocols including circuit and packet forms.";
   
-
-    uses TapiDt:UniversalId;
-
+    leaf uuid{
+    	type TapiDt:UniversalId;
+    }
     
     list _IpList{
       key "layerProtocol";
@@ -336,8 +343,9 @@ module TapiInformationModel {
     "The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. 
     The structure of LTP supports all transport protocols including circuit and packet forms.";
   
-
-    uses TapiDt:UniversalId;
+    leaf uuid{
+    	type TapiDt:UniversalId;
+    }
 
     list _IpList{
       key "layerProtocol";
@@ -374,7 +382,9 @@ module TapiInformationModel {
     The EP replaces the Protection Unit of a traditional protection model. 
     The ForwadingConstruct can be considered as a component and the EndPoint as a Port on that component";
 
-    uses TapiDt:UniversalId; // Differs
+    leaf uuid{
+    	type TapiDt:UniversalId; // Differs
+    }
     
     container connEpRef { // Differs
       uses ConnectionEndPoint;
@@ -392,7 +402,9 @@ module TapiInformationModel {
 
   grouping ServiceEnd {
   
-    uses TapiDt:UniversalId; // Differs
+    leaf uuid{
+    	type TapiDt:UniversalId; // Differs
+    }
   
     container serviceEpRef { // Differs
       uses ConnectionEndPoint;
@@ -414,7 +426,9 @@ module TapiInformationModel {
     The route of an FC object is represented by a list of FCs at a lower level. 
     Note that depending on the service supported by an FC, an the FC can have multiple routes.";
 
-    uses TapiDt:UniversalId;
+    leaf uuid{
+    	type TapiDt:UniversalId; // Differs
+    }
 
     leaf-list _LowerLevelFcList{
       type leafref {
@@ -426,7 +440,9 @@ module TapiInformationModel {
   
   grouping Connection {
 
-    uses TapiDt:UniversalId;
+    leaf uuid{
+    	type TapiDt:UniversalId; // Differs
+    }
 
     list connEndList { // Differs from UML
       key "uuid";
@@ -453,7 +469,9 @@ module TapiInformationModel {
   
   grouping Service {
 
-    uses TapiDt:UniversalId;
+    leaf uuid{
+    	type TapiDt:UniversalId; // Differs
+    }
 
     leaf-list _connectionRefList {
       type leafref {
@@ -475,7 +493,9 @@ module TapiInformationModel {
   
   grouping Context {
   
-    uses TapiDt:UniversalId;   
+    leaf uuid{
+    	type TapiDt:UniversalId; // Differs
+    }  
     
     list topologyList { // Differs from UML
       key "uuid";

--- a/TransportAPI/YANG/TapiInformationModel.yang
+++ b/TransportAPI/YANG/TapiInformationModel.yang
@@ -38,7 +38,10 @@ module TapiInformationModel {
     termination and adaptation functions of one or more transport layers. 
     The structure of LTP supports all transport protocols including circuit and packet forms.";
 
-    uses TapiDt:UniversalId;
+    leaf uuid{
+    	type TapiDt:UniversalId;
+    }
+    
     
     list _IpList{ // Unconsistant
       key "layerProtocol";


### PR DESCRIPTION
Hello,

my name is Arturo Mayoral I'm working with Ricard in CTTC and I create this pull request to merge some changes I performed in the TapiInformationModel.yang and TapiDataTypes.yang models to change the definition of the "uuid" parameter included in several blocks of the Information Model.

My rationale is this parameter just contains a single leaf statement so is worth nothing to declare it as a grouping statement ("TapiDt:UniversalId"), instead I propose to create a "typedef" to define this single data-type.

Regards,
Arturo.