### PR TITLE
Tapi namespace refactoring

### DIFF
--- a/TransportAPI/UML/.settings/stylesheets.xmi
+++ b/TransportAPI/UML/.settings/stylesheets.xmi
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="ASCII"?>
+<css:StyleSheetReference xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:css="http://www.eclipse.org/papyrus/infra/gmfdiag/css" path="/TapiModel/OpenModelClassDiagram.css"/>

--- a/TransportAPI/UML/OpenModelClassDiagram.css
+++ b/TransportAPI/UML/OpenModelClassDiagram.css
@@ -1,0 +1,31 @@
+Class > Compartment[kind="operations"] {
+    visible:false;
+}
+
+Class > Compartment[kind="nestedclassifiers"] {
+    visible:false;
+}
+
+DataType > Compartment[kind="operations"] {
+    visible:false;
+}
+
+Interface > Compartment[kind="attributes"] {
+    visible:false;
+}
+
+Property {
+	maskLabel: name type multiplicity defaultValue;
+}
+
+Property > Label[type=StereotypeLabel]{
+	visible:false;
+}
+
+Operation {
+	maskLabel: name type multiplicity defaultValue;
+}
+
+Operation > Label[type=StereotypeLabel]{
+	visible:false;
+}	

--- a/TransportAPI/UML/TapiModule.di
+++ b/TransportAPI/UML/TapiModule.di
@@ -13,34 +13,22 @@
           <emfPageIdentifier href="TapiModule.notation#_pzJwcETdEeWKAbXi7_SowQ"/>
         </children>
         <children>
-          <emfPageIdentifier href="TapiModule.notation#_V89zkINvEeW35P6IpRw6Dg"/>
+          <emfPageIdentifier href="TapiModule.notation#_ZafwYIMtEeWXiLNtUPJYxg"/>
         </children>
         <children>
           <emfPageIdentifier href="TapiModule.notation#_qpB-0IbkEeWLkaOCu--9xg"/>
         </children>
         <children>
-          <emfPageIdentifier href="TapiModule.notation#_ZafwYIMtEeWXiLNtUPJYxg"/>
+          <emfPageIdentifier href="TapiModule.notation#_Ocb1wO-pEeWLlrwIF3w0vA"/>
         </children>
         <children>
-          <emfPageIdentifier href="TapiModule.notation#_ULR5YKIBEeWqgMj1FXPlrA"/>
-        </children>
-        <children>
-          <emfPageIdentifier href="TapiModule.notation#_3uHDsN6REeWd9KDn6x5Skg"/>
-        </children>
-        <children>
-          <emfPageIdentifier href="TapiModule.notation#_1Fpo4J1EEeWJ0fWjnLbawA"/>
+          <emfPageIdentifier href="TapiModule.notation#__F1tsN8qEeWT9tG0gGLRFw"/>
         </children>
         <children>
           <emfPageIdentifier href="TapiModule.notation#_Je-KAFdKEeW9S_gzu-W_Qw"/>
         </children>
         <children>
-          <emfPageIdentifier href="TapiModule.notation#_wq_GoIN1EeW35P6IpRw6Dg"/>
-        </children>
-        <children>
-          <emfPageIdentifier href="TapiModule.notation#_BbuPgN71EeW-BtRsuJPbqg"/>
-        </children>
-        <children>
-          <emfPageIdentifier href="TapiModule.notation#__F1tsN8qEeWT9tG0gGLRFw"/>
+          <emfPageIdentifier href="TapiModule.notation#_1Fpo4J1EEeWJ0fWjnLbawA"/>
         </children>
       </children>
     </windows>

--- a/TransportAPI/UML/TapiModule.notation
+++ b/TransportAPI/UML/TapiModule.notation
@@ -692,7 +692,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_pzJ4H0TdEeWKAbXi7_SowQ"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pzJ4IETdEeWKAbXi7_SowQ" points="[9, 0, -427, -2]$[9, 68, -427, 66]$[430, 68, -6, 66]$[430, 2, -6, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pzJ4IETdEeWKAbXi7_SowQ" points="[0, 0, -433, -2]$[0, 68, -433, 66]$[433, 68, 0, 66]$[433, 2, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pzJ4IUTdEeWKAbXi7_SowQ" id="(0.3032258064516129,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pzJ4IkTdEeWKAbXi7_SowQ" id="(0.09937888198757763,1.0)"/>
     </edges>
@@ -885,9 +885,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_LILb4WkDEeWZEqTYAF8eqA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_LGsOIGkDEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LILb4mkDEeWZEqTYAF8eqA" points="[-6, 0, -170, -26]$[-6, 32, -170, 6]$[164, 32, 0, 6]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LILb4mkDEeWZEqTYAF8eqA" points="[0, 0, -164, -33]$[0, 36, -164, 3]$[164, 33, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LJg4oGkDEeWZEqTYAF8eqA" id="(0.44715447154471544,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LJg4oWkDEeWZEqTYAF8eqA" id="(0.0,0.71)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LJg4oWkDEeWZEqTYAF8eqA" id="(0.0,0.78)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_m1oIhmkFEeWZEqTYAF8eqA" type="StereotypeCommentLink" source="_m1e-gGkFEeWZEqTYAF8eqA" target="_m1oIgmkFEeWZEqTYAF8eqA">
       <styles xmi:type="notation:FontStyle" xmi:id="_m1oIh2kFEeWZEqTYAF8eqA"/>
@@ -928,7 +928,7 @@
       <element xmi:type="uml:Association" href="TapiModule.uml#_nttnAGkFEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nu550mkFEeWZEqTYAF8eqA" points="[2, 23, 0, -71]$[3, 71, 1, -23]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nv8boGkFEeWZEqTYAF8eqA" id="(0.5211267605633803,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nv8boWkFEeWZEqTYAF8eqA" id="(0.5037037037037037,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nv8boWkFEeWZEqTYAF8eqA" id="(0.6509433962264151,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ikoicGkHEeWZEqTYAF8eqA" type="4001" source="_m1e-gGkFEeWZEqTYAF8eqA" target="_pzJ0QkTdEeWKAbXi7_SowQ">
       <children xmi:type="notation:DecorationNode" xmi:id="_ikoic2kHEeWZEqTYAF8eqA" type="6001">
@@ -1012,7 +1012,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Y0bhwWkJEeWZEqTYAF8eqA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_YyfoEGkJEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y0bhwmkJEeWZEqTYAF8eqA" points="[7, 20, 0, -90]$[19, 86, 12, -24]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y1w-gGkJEeWZEqTYAF8eqA" id="(0.4351851851851852,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y1w-gGkJEeWZEqTYAF8eqA" id="(0.4857142857142857,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y1w-gWkJEeWZEqTYAF8eqA" id="(0.573170731707317,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_njorsGkKEeWZEqTYAF8eqA" type="4001" source="_pzJxfETdEeWKAbXi7_SowQ" target="_pzJ1LETdEeWKAbXi7_SowQ">
@@ -1061,7 +1061,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_ZeDIwX5NEeWWkJKpap4S3A"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_Zb5MoH5NEeWWkJKpap4S3A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZeDIwn5NEeWWkJKpap4S3A" points="[7, 0, 478, 2]$[7, 92, 478, 94]$[-478, 92, -7, 94]$[-478, -2, -7, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZeDIwn5NEeWWkJKpap4S3A" points="[0, 0, 465, 2]$[0, 92, 465, 94]$[-465, 92, 0, 94]$[-465, -2, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZfyOIH5NEeWWkJKpap4S3A" id="(0.19254658385093168,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZfyOIX5NEeWWkJKpap4S3A" id="(0.17419354838709677,1.0)"/>
     </edges>
@@ -1107,7 +1107,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_-rmzUaIiEeWDu_9VgujMbw"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_cfZ_cIbpEeWLkaOCu--9xg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-rmzUqIiEeWDu_9VgujMbw" points="[0, 0, 74, 0]$[0, 55, 74, 55]$[-67, 55, 7, 55]$[-67, 0, 7, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-rmzUqIiEeWDu_9VgujMbw" points="[0, 0, 61, 0]$[0, 55, 61, 55]$[-58, 55, 3, 55]$[-61, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NjmiUKIjEeWDu_9VgujMbw" id="(0.8757763975155279,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NkM_QKIjEeWDu_9VgujMbw" id="(0.4161490683229814,1.0)"/>
     </edges>
@@ -1157,7 +1157,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_PvhjQaf1EeW6jfwWQNiYcg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_9-A9gD_KEeWNAdBR30aJhw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PvhjQqf1EeW6jfwWQNiYcg" points="[0, 0, 256, 86]$[-249, 0, 7, 86]$[-249, -86, 7, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PvhjQqf1EeW6jfwWQNiYcg" points="[0, 0, 256, 86]$[-256, 0, 0, 86]$[-256, -86, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q_WMYKf1EeW6jfwWQNiYcg" id="(0.0,0.2)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RAA6wKf1EeW6jfwWQNiYcg" id="(0.5133333333333333,1.0)"/>
     </edges>
@@ -1251,12 +1251,12 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_G47csdnfEeWIOYiRCk5bbQ"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_G1pfMNnfEeWIOYiRCk5bbQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G47cstnfEeWIOYiRCk5bbQ" points="[0, 0, 0, -69]$[-88, 0, -88, -69]$[-88, 59, -88, -10]$[0, 69, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_G47cstnfEeWIOYiRCk5bbQ" points="[0, 0, 0, -55]$[-88, 0, -88, -55]$[-88, 55, -88, 0]$[0, 55, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6Q5cNnfEeWIOYiRCk5bbQ" id="(0.0,0.18)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_G6Q5cdnfEeWIOYiRCk5bbQ" id="(0.0,0.73)"/>
     </edges>
   </notation:Diagram>
-  <notation:Diagram xmi:id="_Je-KAFdKEeW9S_gzu-W_Qw" type="PapyrusUMLClassDiagram" name="Tapi Data Types" measurementUnit="Pixel">
+  <notation:Diagram xmi:id="_Je-KAFdKEeW9S_gzu-W_Qw" type="PapyrusUMLClassDiagram" name="Data Types" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="_-WV0N2kaEeWZEqTYAF8eqA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_-WV0OGkaEeWZEqTYAF8eqA" showTitle="true"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-WV0OmkaEeWZEqTYAF8eqA" name="BASE_ELEMENT"/>
@@ -1405,7 +1405,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gY9cmb9gEeW8HsosJj6psA"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiModule.uml#_smkSYL1yEeWdore3Cxez9g"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gY9ckb9gEeW8HsosJj6psA" x="806" y="404" height="201"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gY9ckb9gEeW8HsosJj6psA" x="849" y="403" height="201"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_9ua9479kEeW8HsosJj6psA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_9ua95L9kEeW8HsosJj6psA" showTitle="true"/>
@@ -1629,7 +1629,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_86zEPt8DEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiModule.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_86zEMd8DEeW-BtRsuJPbqg" x="1" y="320" height="87"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_86zEMd8DEeW-BtRsuJPbqg" x="1" y="320" height="78"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BF_5UN8EEeW-BtRsuJPbqg" type="2010">
       <children xmi:type="notation:DecorationNode" xmi:id="_BF_5Ut8EEeW-BtRsuJPbqg" type="5035"/>
@@ -1661,7 +1661,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BGJDS98EEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiModule.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BF_5Ud8EEeW-BtRsuJPbqg" x="276" y="319" height="111"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BF_5Ud8EEeW-BtRsuJPbqg" x="144" y="310" height="111"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_ULIXIN8EEeW-BtRsuJPbqg" type="2006">
       <children xmi:type="notation:DecorationNode" xmi:id="_ULIXIt8EEeW-BtRsuJPbqg" type="5023"/>
@@ -1821,7 +1821,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_triZ3t8FEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiModule.uml#_8ZRqwdv-EeWowYqZXEhn3A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_triZ0d8FEeW-BtRsuJPbqg" x="368" y="605" height="111"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_triZ0d8FEeW-BtRsuJPbqg" x="470" y="455" height="111"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_3vcHsN8FEeW-BtRsuJPbqg" type="2010">
       <children xmi:type="notation:DecorationNode" xmi:id="_3vcHst8FEeW-BtRsuJPbqg" type="5035"/>
@@ -1849,7 +1849,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3vcHvt8FEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiModule.uml#_8ZRq-dv-EeWowYqZXEhn3A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3vcHsd8FEeW-BtRsuJPbqg" x="682" y="620" height="96"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3vcHsd8FEeW-BtRsuJPbqg" x="645" y="464" height="96"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_-aax8N8FEeW-BtRsuJPbqg" type="2010">
       <children xmi:type="notation:DecorationNode" xmi:id="_-aax8t8FEeW-BtRsuJPbqg" type="5035"/>
@@ -1877,7 +1877,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-aax_t8FEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiModule.uml#_8ZRqz9v-EeWowYqZXEhn3A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-aax8d8FEeW-BtRsuJPbqg" x="-6" y="613" height="97"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-aax8d8FEeW-BtRsuJPbqg" x="241" y="461" height="97"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DjXBsN8GEeW-BtRsuJPbqg" type="2010">
       <children xmi:type="notation:DecorationNode" xmi:id="_DjXBst8GEeW-BtRsuJPbqg" type="5035"/>
@@ -1909,7 +1909,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DjgLq98GEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:DataType" href="TapiModule.uml#_8ZRq69v-EeWowYqZXEhn3A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DjXBsd8GEeW-BtRsuJPbqg" x="383" y="456" height="114"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DjXBsd8GEeW-BtRsuJPbqg" x="519" y="303" height="114"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_Je-KAVdKEeW9S_gzu-W_Qw" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_Je-KAldKEeW9S_gzu-W_Qw"/>
@@ -2258,7 +2258,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GAPFQYMvEeWXiLNtUPJYxg"/>
       </children>
       <element xmi:type="uml:Interface" href="TapiModule.uml#_-ht5oPMtEeSb-q8_djA2ng"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GAFUMYMvEeWXiLNtUPJYxg" x="14" y="186" width="170" height="58"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GAFUMYMvEeWXiLNtUPJYxg" x="18" y="163" width="170" height="58"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_GAiAI4MvEeWXiLNtUPJYxg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_GAiAJIMvEeWXiLNtUPJYxg" showTitle="true"/>
@@ -2297,74 +2297,6 @@
       <children xmi:type="notation:DecorationNode" xmi:id="_G3aqo7rvEeWYrqoqXLgguw" type="5159"/>
       <element xmi:type="uml:Constraint" href="TapiModule.uml#_v3DA8LrbEeWYrqoqXLgguw"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G3aqobrvEeWYrqoqXLgguw" x="541" y="94" height="48"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_pU4loN7kEeW-BtRsuJPbqg" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_pVCWoN7kEeW-BtRsuJPbqg" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_pVCWod7kEeW-BtRsuJPbqg" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_pVCWot7kEeW-BtRsuJPbqg" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_pVCWo97kEeW-BtRsuJPbqg" visible="false" type="7017">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_pVCWpN7kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_pVCWpd7kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_pVCWpt7kEeW-BtRsuJPbqg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pVCWp97kEeW-BtRsuJPbqg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_pVCWqN7kEeW-BtRsuJPbqg" visible="false" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_pVCWqd7kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_pVCWqt7kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_pVCWq97kEeW-BtRsuJPbqg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pVCWrN7kEeW-BtRsuJPbqg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_pVCWrd7kEeW-BtRsuJPbqg" visible="false" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_pVCWrt7kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_pVCWr97kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_pVCWsN7kEeW-BtRsuJPbqg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pVCWsd7kEeW-BtRsuJPbqg"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiModule.uml#_KjZXXNyKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pU4lod7kEeW-BtRsuJPbqg" x="740" y="604" width="148" height="60"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_pVLgot7kEeW-BtRsuJPbqg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_pVLgo97kEeW-BtRsuJPbqg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pVLgpd7kEeW-BtRsuJPbqg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_KjZXXNyKEeWXdJnxZxtFYA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pVLgpN7kEeW-BtRsuJPbqg" x="200"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_zUK5QN7kEeW-BtRsuJPbqg" type="2008">
-      <children xmi:type="notation:DecorationNode" xmi:id="_zUK5Qt7kEeW-BtRsuJPbqg" type="5029"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_zUK5Q97kEeW-BtRsuJPbqg" type="8510">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_zUK5RN7kEeW-BtRsuJPbqg" y="5"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_zUK5Rd7kEeW-BtRsuJPbqg" visible="false" type="7017">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_zUK5Rt7kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_zUK5R97kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_zUK5SN7kEeW-BtRsuJPbqg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUK5Sd7kEeW-BtRsuJPbqg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_zUUDMN7kEeW-BtRsuJPbqg" visible="false" type="7018">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_zUUDMd7kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_zUUDMt7kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_zUUDM97kEeW-BtRsuJPbqg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUUDNN7kEeW-BtRsuJPbqg"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_zUUDNd7kEeW-BtRsuJPbqg" visible="false" type="7019">
-        <styles xmi:type="notation:TitleStyle" xmi:id="_zUUDNt7kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_zUUDN97kEeW-BtRsuJPbqg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_zUUDON7kEeW-BtRsuJPbqg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUUDOd7kEeW-BtRsuJPbqg"/>
-      </children>
-      <element xmi:type="uml:Class" href="TapiModule.uml#_KjZW_dyKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUK5Qd7kEeW-BtRsuJPbqg" x="740" y="699" height="57"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_zUm-I97kEeW-BtRsuJPbqg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_zUm-JN7kEeW-BtRsuJPbqg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUm-Jt7kEeW-BtRsuJPbqg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_KjZW_dyKEeWXdJnxZxtFYA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zUm-Jd7kEeW-BtRsuJPbqg" x="200"/>
     </children>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_Zaf0aIMtEeWXiLNtUPJYxg"/>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_Zaf0aYMtEeWXiLNtUPJYxg" name="diagram_compatibility_version" stringValue="1.1.0"/>
@@ -2469,8 +2401,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Zaf0p4MtEeWXiLNtUPJYxg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_GkchcD_DEeWNAdBR30aJhw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Zaf0qIMtEeWXiLNtUPJYxg" points="[0, 0, 0, -240]$[0, 240, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zaf0qYMtEeWXiLNtUPJYxg" id="(0.09333333333333334,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zaf0qoMtEeWXiLNtUPJYxg" id="(0.13821138211382114,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zaf0qYMtEeWXiLNtUPJYxg" id="(0.11229946524064172,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zaf0qoMtEeWXiLNtUPJYxg" id="(0.13333333333333333,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Zaf0q4MtEeWXiLNtUPJYxg" type="4001" source="_ZafwYYMtEeWXiLNtUPJYxg" target="_Zafwk4MtEeWXiLNtUPJYxg">
       <children xmi:type="notation:DecorationNode" xmi:id="_Zaf0rIMtEeWXiLNtUPJYxg" type="6001">
@@ -2604,8 +2536,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Zaf1d4MtEeWXiLNtUPJYxg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_tQQ4UGj_EeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Zaf1eIMtEeWXiLNtUPJYxg" points="[-21, -52, 199, 501]$[-220, -553, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zaf1eYMtEeWXiLNtUPJYxg" id="(0.15555555555555556,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zaf1eoMtEeWXiLNtUPJYxg" id="(0.46218487394957986,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zaf1eYMtEeWXiLNtUPJYxg" id="(0.16267942583732056,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zaf1eoMtEeWXiLNtUPJYxg" id="(0.5126050420168067,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Zaf1e4MtEeWXiLNtUPJYxg" type="4001" source="_ZafwxYMtEeWXiLNtUPJYxg" target="_ZafzeoMtEeWXiLNtUPJYxg">
       <children xmi:type="notation:DecorationNode" xmi:id="_Zaf1fIMtEeWXiLNtUPJYxg" type="6001">
@@ -2679,7 +2611,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_eGQGIoMzEeWXiLNtUPJYxg"/>
       <element xmi:type="uml:Usage" href="TapiModule.uml#_eGQGIIMzEeWXiLNtUPJYxg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eGQGI4MzEeWXiLNtUPJYxg" points="[9, 0, -228, 159]$[9, -159, -228, 0]$[237, -159, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eGQGI4MzEeWXiLNtUPJYxg" points="[0, 0, -233, 136]$[0, -136, -233, 0]$[233, -136, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eHbK0IMzEeWXiLNtUPJYxg" id="(0.5882352941176471,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eHbK0YMzEeWXiLNtUPJYxg" id="(0.0,0.17647058823529413)"/>
     </edges>
@@ -2692,9 +2624,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_pzfJUoMzEeWXiLNtUPJYxg"/>
       <element xmi:type="uml:Usage" href="TapiModule.uml#_pzfJUIMzEeWXiLNtUPJYxg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pzfJU4MzEeWXiLNtUPJYxg" points="[0, 0, -147, 47]$[110, 0, -37, 47]$[147, -47, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pzfJU4MzEeWXiLNtUPJYxg" points="[0, 0, -143, 24]$[143, -24, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_p0X6IIMzEeWXiLNtUPJYxg" id="(1.0,0.13793103448275862)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_p0X6IYMzEeWXiLNtUPJYxg" id="(0.0,0.1346153846153846)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_p0X6IYMzEeWXiLNtUPJYxg" id="(0.0,0.5961538461538461)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_VmWIUIM4EeWXiLNtUPJYxg" type="4007" source="_GAFUMIMvEeWXiLNtUPJYxg" target="_Zafwk4MtEeWXiLNtUPJYxg">
       <children xmi:type="notation:DecorationNode" xmi:id="_VmWIU4M4EeWXiLNtUPJYxg" type="6016">
@@ -2709,7 +2641,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_VmWIUYM4EeWXiLNtUPJYxg"/>
       <element xmi:type="uml:Usage" href="TapiModule.uml#_VmM-YIM4EeWXiLNtUPJYxg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VmWIUoM4EeWXiLNtUPJYxg" points="[0, 0, -255, -119]$[106, 0, -149, -119]$[106, 119, -149, 0]$[255, 119, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VnbtcIM4EeWXiLNtUPJYxg" id="(1.0,0.3793103448275862)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VnbtcIM4EeWXiLNtUPJYxg" id="(1.0,0.6896551724137931)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VnbtcYM4EeWXiLNtUPJYxg" id="(0.0,0.7358490566037735)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_tQ5BV4NUEeW35P6IpRw6Dg" type="StereotypeCommentLink" target="_tQ5BU4NUEeW35P6IpRw6Dg">
@@ -2731,9 +2663,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_LsUFIYNZEeW35P6IpRw6Dg"/>
       <element xmi:type="uml:Usage" href="TapiModule.uml#_LsKUIINZEeW35P6IpRw6Dg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LsUFIoNZEeW35P6IpRw6Dg" points="[7, 0, -167, -226]$[7, 220, -167, -6]$[174, 220, 0, -6]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LsUFIoNZEeW35P6IpRw6Dg" points="[0, 0, -170, -234]$[0, 234, -170, 0]$[170, 234, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lt8c0INZEeW35P6IpRw6Dg" id="(0.8352941176470589,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lt8c0YNZEeW35P6IpRw6Dg" id="(0.0,0.7090909090909091)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Lt8c0YNZEeW35P6IpRw6Dg" id="(0.0,0.43636363636363634)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_RNpmwINZEeW35P6IpRw6Dg" type="4007" source="_GAFUMIMvEeWXiLNtUPJYxg" target="_Zafxo4MtEeWXiLNtUPJYxg">
       <children xmi:type="notation:DecorationNode" xmi:id="_RNpmw4NZEeW35P6IpRw6Dg" type="6016">
@@ -2746,7 +2678,7 @@
       <element xmi:type="uml:Usage" href="TapiModule.uml#_RNf1wINZEeW35P6IpRw6Dg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RNpmwoNZEeW35P6IpRw6Dg" points="[0, 0, -303, -471]$[0, 471, -303, 0]$[303, 471, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RO_DgINZEeW35P6IpRw6Dg" id="(0.31176470588235294,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RO_DgYNZEeW35P6IpRw6Dg" id="(0.0,0.7192982456140351)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RO_DgYNZEeW35P6IpRw6Dg" id="(0.0,0.3684210526315789)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_QlmAILrvEeWYrqoqXLgguw" type="4014" source="_G3aqoLrvEeWYrqoqXLgguw" target="_Zaf0vIMtEeWXiLNtUPJYxg">
       <styles xmi:type="notation:FontStyle" xmi:id="_QlmAIbrvEeWYrqoqXLgguw"/>
@@ -2761,26 +2693,6 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ROgaQrrvEeWYrqoqXLgguw" points="[-9, 6, 131, 5]$[-140, -5, 0, -6]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RQJZALrvEeWYrqoqXLgguw" id="(0.0,0.5625)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RQJZAbrvEeWYrqoqXLgguw" id="(1.0,0.7333333333333333)"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_pVLgpt7kEeW-BtRsuJPbqg" type="StereotypeCommentLink" source="_pU4loN7kEeW-BtRsuJPbqg" target="_pVLgot7kEeW-BtRsuJPbqg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_pVLgp97kEeW-BtRsuJPbqg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_pVLgq97kEeW-BtRsuJPbqg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_KjZXXNyKEeWXdJnxZxtFYA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pVLgqN7kEeW-BtRsuJPbqg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pVLgqd7kEeW-BtRsuJPbqg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pVLgqt7kEeW-BtRsuJPbqg"/>
-    </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_zUm-J97kEeW-BtRsuJPbqg" type="StereotypeCommentLink" source="_zUK5QN7kEeW-BtRsuJPbqg" target="_zUm-I97kEeW-BtRsuJPbqg">
-      <styles xmi:type="notation:FontStyle" xmi:id="_zUm-KN7kEeW-BtRsuJPbqg"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zUm-LN7kEeW-BtRsuJPbqg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_KjZW_dyKEeWXdJnxZxtFYA"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zUm-Kd7kEeW-BtRsuJPbqg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUm-Kt7kEeW-BtRsuJPbqg"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zUm-K97kEeW-BtRsuJPbqg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_V89zkINvEeW35P6IpRw6Dg" type="PapyrusUMLClassDiagram" name="Topology Service Overview" measurementUnit="Pixel">
@@ -3865,29 +3777,41 @@
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_p2F0QN7vEeW-BtRsuJPbqg" source="PapyrusCSSForceValue">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_p2F0Qd7vEeW-BtRsuJPbqg" key="visible" value="true"/>
         </eAnnotations>
-        <children xmi:type="notation:Shape" xmi:id="_pdJyAN7-EeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_YQ9egO_jEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_Iz0OAKf4EeW6jfwWQNiYcg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YQ9ege_jEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_YQ9egu_jEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_T3VIQT_NEeWNAdBR30aJhw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YQ9eg-_jEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_YQ9ehO_jEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_T7gvkz_LEeWNAdBR30aJhw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YQ9ehe_jEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_YQ9ehu_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_W9zh097-EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_pdJyAd7-EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YQ9eh-_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_rk_BMN7-EeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_YQ9eiO_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_tOFAk97rEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_rk_BMd7-EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YQ9eie_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_rk_BMt7-EeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_YQ9eiu_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_7DdfM97vEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_rk_BM97-EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YQ9ei-_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_rk_BNN7-EeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_YQ9ejO_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_lqLYA97wEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_rk_BNd7-EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YQ9eje_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_rk_BNt7-EeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_YQ9eju_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_kTBiY97xEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_rk_BN97-EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YQ9ej-_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_t4-DwN8DEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_YQ9ekO_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_xImb1OK4EeSq5fATALSQkQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_t4-Dwd8DEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_YQ9eke_jEeWLlrwIF3w0vA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_B9TMNt7tEeW-BtRsuJPbqg" showTitle="true"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_B9TMN97tEeW-BtRsuJPbqg"/>
@@ -3907,7 +3831,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B9TMQ97tEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_xImb0OK4EeSq5fATALSQkQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B9TMMd7tEeW-BtRsuJPbqg" x="-308" y="251" height="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B9TMMd7tEeW-BtRsuJPbqg" x="-308" y="224" height="203"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_B9v4I97tEeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_B9v4JN7tEeW-BtRsuJPbqg" showTitle="true"/>
@@ -3957,7 +3881,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z7qoE97tEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z7qoAd7tEeW-BtRsuJPbqg" x="327" y="39" height="121"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z7qoAd7tEeW-BtRsuJPbqg" x="117" y="34" height="121"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_z79i897tEeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_z79i9N7tEeW-BtRsuJPbqg" showTitle="true"/>
@@ -3998,7 +3922,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8e_7E97tEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZW8dyKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8e_7Ad7tEeW-BtRsuJPbqg" x="326" y="182" height="77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8e_7Ad7tEeW-BtRsuJPbqg" x="118" y="186" height="77"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_8fS2At7tEeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_8fS2A97tEeW-BtRsuJPbqg" showTitle="true"/>
@@ -4056,7 +3980,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MODN497uEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZXGdyKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MODN0d7uEeW-BtRsuJPbqg" x="324" y="278" height="156"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MODN0d7uEeW-BtRsuJPbqg" x="97" y="283" height="156"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_MOWIw97uEeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_MOWIxN7uEeW-BtRsuJPbqg" showTitle="true"/>
@@ -4106,7 +4030,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TkDLE97uEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZXB9yKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TkDLAd7uEeW-BtRsuJPbqg" x="328" y="459" height="126"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TkDLAd7uEeW-BtRsuJPbqg" x="117" y="468" height="126"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_TkWGAt7uEeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_TkWGA97uEeW-BtRsuJPbqg" showTitle="true"/>
@@ -4131,14 +4055,6 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_vqMrdd7wEeW-BtRsuJPbqg" x="249" y="179"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_xtdHM97xEeW-BtRsuJPbqg" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_xtdHNN7xEeW-BtRsuJPbqg" showTitle="true"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xtdHNt7xEeW-BtRsuJPbqg" name="BASE_ELEMENT">
-        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_kTBiYN7xEeW-BtRsuJPbqg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xtdHNd7xEeW-BtRsuJPbqg" x="249" y="179"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_RHf1wN7-EeW-BtRsuJPbqg" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="_RHf1wt7-EeW-BtRsuJPbqg" type="5029"/>
@@ -4176,7 +4092,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RHf1097-EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RHf1wd7-EeW-BtRsuJPbqg" x="-287" y="495" height="116"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RHf1wd7-EeW-BtRsuJPbqg" x="-291" y="494" height="116"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_RHywwt7-EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_RHyww97-EeW-BtRsuJPbqg" showTitle="true"/>
@@ -4234,7 +4150,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVmXc98BEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVmXYd8BEeW-BtRsuJPbqg" x="-272" y="36" height="125"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QVmXYd8BEeW-BtRsuJPbqg" x="-245" y="56" height="125"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_QV5SU98BEeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_QV5SVN8BEeW-BtRsuJPbqg" showTitle="true"/>
@@ -4251,6 +4167,14 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3knzdd80EeWT9tG0gGLRFw" x="527" y="-61"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_L9WJHu_pEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_L9WJH-_pEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L9WJIe_pEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_kTBiYN7xEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_L9WJIO_pEeWLlrwIF3w0vA" x="-108" y="124"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_wq_PJ4N1EeW35P6IpRw6Dg" name="diagram_compatibility_version" stringValue="1.1.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_wq_PKIN1EeW35P6IpRw6Dg"/>
@@ -4541,9 +4465,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_seWP8d7vEeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_tOFAkN7rEeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_seWP8t7vEeW-BtRsuJPbqg" points="[0, 6, 183, -213]$[-140, 6, 43, -213]$[-140, 219, 43, 0]$[-173, 219, 10, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xBWhEN7vEeW-BtRsuJPbqg" id="(0.0,0.14049586776859505)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xBWhEd7vEeW-BtRsuJPbqg" id="(1.0,0.08227848101265822)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_seWP8t7vEeW-BtRsuJPbqg" points="[0, 0, 137, -188]$[-110, 0, 27, -188]$[-110, 188, 27, 0]$[-137, 188, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xBWhEN7vEeW-BtRsuJPbqg" id="(0.0,0.1322314049586777)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xBWhEd7vEeW-BtRsuJPbqg" id="(1.0,0.06896551724137931)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7HnmcN7vEeW-BtRsuJPbqg" type="4001" source="_B9TMMN7tEeW-BtRsuJPbqg" target="_8e_7AN7tEeW-BtRsuJPbqg">
       <children xmi:type="notation:DecorationNode" xmi:id="_7Hnmc97vEeW-BtRsuJPbqg" type="6001">
@@ -4566,8 +4490,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_7Hnmcd7vEeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_7DdfMN7vEeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7Hnmct7vEeW-BtRsuJPbqg" points="[0, -5, -184, 102]$[84, -5, -100, 102]$[84, -92, -100, 15]$[184, -107, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7IXNUN7vEeW-BtRsuJPbqg" id="(1.0,0.3333333333333333)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7Hnmct7vEeW-BtRsuJPbqg" points="[0, 0, -138, 67]$[65, 0, -73, 67]$[65, -67, -73, 0]$[138, -67, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7IXNUN7vEeW-BtRsuJPbqg" id="(1.0,0.33125)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7IXNUd7vEeW-BtRsuJPbqg" id="(0.0,0.4935064935064935)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_C_hW197wEeW-BtRsuJPbqg" type="StereotypeCommentLink" source="_7HnmcN7vEeW-BtRsuJPbqg" target="_C_hW097wEeW-BtRsuJPbqg">
@@ -4582,7 +4506,7 @@
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_lvO3IN7wEeW-BtRsuJPbqg" type="4001" source="_B9TMMN7tEeW-BtRsuJPbqg" target="_MODN0N7uEeW-BtRsuJPbqg">
       <children xmi:type="notation:DecorationNode" xmi:id="_lvO3I97wEeW-BtRsuJPbqg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lvO3JN7wEeW-BtRsuJPbqg" x="4" y="9"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lvO3JN7wEeW-BtRsuJPbqg" x="1" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_lvO3Jd7wEeW-BtRsuJPbqg" visible="false" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_lvO3Jt7wEeW-BtRsuJPbqg" y="20"/>
@@ -4594,7 +4518,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_lvO3Kt7wEeW-BtRsuJPbqg" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_lvO3K97wEeW-BtRsuJPbqg" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_lvO3LN7wEeW-BtRsuJPbqg" x="15" y="18"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_lvO3LN7wEeW-BtRsuJPbqg" x="8" y="16"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_lvO3Ld7wEeW-BtRsuJPbqg" type="6034">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_lvO3Lt7wEeW-BtRsuJPbqg" x="-7" y="17"/>
@@ -4602,8 +4526,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_lvO3Id7wEeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_lqLYAN7wEeW-BtRsuJPbqg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lvO3It7wEeW-BtRsuJPbqg" points="[7, -1, -181, 16]$[177, -18, -11, -1]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwRY8N7wEeW-BtRsuJPbqg" id="(1.0,0.5506329113924051)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwRY8d7wEeW-BtRsuJPbqg" id="(0.0,0.38461538461538464)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwRY8N7wEeW-BtRsuJPbqg" id="(1.0,0.5320197044334976)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lwRY8d7wEeW-BtRsuJPbqg" id="(0.0,0.3141025641025641)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_vqMrd97wEeW-BtRsuJPbqg" type="StereotypeCommentLink" source="_lvO3IN7wEeW-BtRsuJPbqg" target="_vqMrc97wEeW-BtRsuJPbqg">
       <styles xmi:type="notation:FontStyle" xmi:id="_vqMreN7wEeW-BtRsuJPbqg"/>
@@ -4636,11 +4560,11 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_kWvkwd7xEeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_kTBiYN7xEeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kWvkwt7xEeW-BtRsuJPbqg" points="[0, 1, -186, -121]$[81, 1, -105, -121]$[81, 122, -105, 0]$[186, 122, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kXyGkN7xEeW-BtRsuJPbqg" id="(1.0,0.8734177215189873)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kXyGkd7xEeW-BtRsuJPbqg" id="(0.0,0.3333333333333333)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kWvkwt7xEeW-BtRsuJPbqg" points="[0, 0, -137, -109]$[63, 0, -74, -109]$[63, 109, -74, 0]$[137, 109, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kXyGkN7xEeW-BtRsuJPbqg" id="(1.0,0.86625)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kXyGkd7xEeW-BtRsuJPbqg" id="(0.0,0.3238095238095238)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_xtdHN97xEeW-BtRsuJPbqg" type="StereotypeCommentLink" source="_kWvkwN7xEeW-BtRsuJPbqg" target="_xtdHM97xEeW-BtRsuJPbqg">
+    <edges xmi:type="notation:Connector" xmi:id="_xtdHN97xEeW-BtRsuJPbqg" type="StereotypeCommentLink" source="_kWvkwN7xEeW-BtRsuJPbqg">
       <styles xmi:type="notation:FontStyle" xmi:id="_xtdHON7xEeW-BtRsuJPbqg"/>
       <styles xmi:type="notation:EObjectValueStyle" xmi:id="_xtdHPN7xEeW-BtRsuJPbqg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_kTBiYN7xEeW-BtRsuJPbqg"/>
@@ -4682,8 +4606,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_XBYaQd7-EeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_W9zh0N7-EeW-BtRsuJPbqg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XBYaQt7-EeW-BtRsuJPbqg" points="[0, -11, 6, 146]$[0, -99, 6, 58]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XCRLEN7-EeW-BtRsuJPbqg" id="(0.5311111111111111,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XCRLEd7-EeW-BtRsuJPbqg" id="(0.5141509433962265,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XCRLEN7-EeW-BtRsuJPbqg" id="(0.5243055555555556,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XCRLEd7-EeW-BtRsuJPbqg" id="(0.5114503816793893,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_jJYG197-EeW-BtRsuJPbqg" type="StereotypeCommentLink" source="_XBYaQN7-EeW-BtRsuJPbqg" target="_jJYG097-EeW-BtRsuJPbqg">
       <styles xmi:type="notation:FontStyle" xmi:id="_jJYG2N7-EeW-BtRsuJPbqg"/>
@@ -4712,8 +4636,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_XCNZUd8BEeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Generalization" href="TapiModule.uml#_W9J6MN8BEeW-BtRsuJPbqg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_XCNZUt8BEeW-BtRsuJPbqg" points="[-7, -22, 24, 153]$[19, -112, 50, 63]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XDZsIN8BEeW-BtRsuJPbqg" id="(0.5355555555555556,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XDZsId8BEeW-BtRsuJPbqg" id="(0.5710227272727273,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XDZsIN8BEeW-BtRsuJPbqg" id="(0.5304964539007092,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_XDZsId8BEeW-BtRsuJPbqg" id="(0.46842105263157896,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_3knzd980EeWT9tG0gGLRFw" type="StereotypeCommentLink" source="_seWP8N7vEeW-BtRsuJPbqg" target="_3knzc980EeWT9tG0gGLRFw">
       <styles xmi:type="notation:FontStyle" xmi:id="_3knzeN80EeWT9tG0gGLRFw"/>
@@ -4724,6 +4648,16 @@
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3knzed80EeWT9tG0gGLRFw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3knzet80EeWT9tG0gGLRFw"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3knze980EeWT9tG0gGLRFw"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_L9WJIu_pEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_kWvkwN7xEeW-BtRsuJPbqg" target="_L9WJHu_pEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_L9WJI-_pEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_L9WJJ-_pEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_kTBiYN7xEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_L9WJJO_pEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L9WJJe_pEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_L9WJJu_pEeWLlrwIF3w0vA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_qpB-0IbkEeWLkaOCu--9xg" type="PapyrusUMLClassDiagram" name="Connectivity Service Skeleton" measurementUnit="Pixel">
@@ -5204,7 +5138,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_qpCDZ4bkEeWLkaOCu--9xg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_MM4s4EHBEeWqPKyD1j6LMg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCDaIbkEeWLkaOCu--9xg" points="[-6, 0, 535, 23]$[-6, 99, 535, 122]$[-535, 99, 6, 122]$[-535, -23, 6, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCDaIbkEeWLkaOCu--9xg" points="[0, 0, 541, 23]$[0, 99, 541, 122]$[-541, 99, 0, 122]$[-541, -23, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCDaYbkEeWLkaOCu--9xg" id="(0.7741935483870968,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCDaobkEeWLkaOCu--9xg" id="(0.3231707317073171,1.0)"/>
     </edges>
@@ -5229,7 +5163,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_qpCDeIbkEeWLkaOCu--9xg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCDeYbkEeWLkaOCu--9xg" points="[0, 0, 163, -1]$[0, 83, 163, 82]$[-163, 83, 0, 82]$[-163, 1, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCDeYbkEeWLkaOCu--9xg" points="[0, 0, 183, -1]$[0, 83, 183, 82]$[-183, 83, 0, 82]$[-183, 1, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCDeobkEeWLkaOCu--9xg" id="(0.45806451612903226,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCDe4bkEeWLkaOCu--9xg" id="(0.6583850931677019,1.0)"/>
     </edges>
@@ -5312,7 +5246,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_qpCDv4bkEeWLkaOCu--9xg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_4ErWsEUcEeWEwNCluy4jrw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCDwIbkEeWLkaOCu--9xg" points="[8, 0, -191, -11]$[8, -34, -191, -45]$[191, -34, -8, -45]$[191, 11, -8, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCDwIbkEeWLkaOCu--9xg" points="[0, 0, -199, -11]$[0, -34, -199, -45]$[199, -34, 0, -45]$[199, 11, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCDwYbkEeWLkaOCu--9xg" id="(0.61875,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCDwobkEeWLkaOCu--9xg" id="(0.1619718309859155,0.0)"/>
     </edges>
@@ -5380,7 +5314,7 @@
       <element xmi:type="uml:Association" href="TapiModule.uml#_nttnAGkFEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCEFIbkEeWLkaOCu--9xg" points="[2, 23, 0, -71]$[3, 71, 1, -23]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEFYbkEeWLkaOCu--9xg" id="(0.5140845070422535,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEFobkEeWLkaOCu--9xg" id="(0.5111111111111111,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEFobkEeWLkaOCu--9xg" id="(0.6415094339622641,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qpCEF4bkEeWLkaOCu--9xg" type="4001" source="_qpCCOIbkEeWLkaOCu--9xg" target="_qpCAr4bkEeWLkaOCu--9xg">
       <children xmi:type="notation:DecorationNode" xmi:id="_qpCEGIbkEeWLkaOCu--9xg" type="6001">
@@ -5404,8 +5338,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_qpCEJIbkEeWLkaOCu--9xg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_ijcPoGkHEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCEJYbkEeWLkaOCu--9xg" points="[-3, 22, 30, -122]$[8, 92, 41, -52]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEJobkEeWLkaOCu--9xg" id="(0.706766917293233,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEJ4bkEeWLkaOCu--9xg" id="(0.6335403726708074,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEJobkEeWLkaOCu--9xg" id="(0.6037735849056604,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEJ4bkEeWLkaOCu--9xg" id="(0.6287878787878788,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qpCEKIbkEeWLkaOCu--9xg" type="StereotypeCommentLink" source="_qpCChobkEeWLkaOCu--9xg" target="_qpCCuIbkEeWLkaOCu--9xg">
       <styles xmi:type="notation:FontStyle" xmi:id="_qpCEKYbkEeWLkaOCu--9xg"/>
@@ -5440,7 +5374,7 @@
       <element xmi:type="uml:Association" href="TapiModule.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCEPIbkEeWLkaOCu--9xg" points="[4, 52, 0, -98]$[7, 130, 3, -20]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEPYbkEeWLkaOCu--9xg" id="(0.51875,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEPobkEeWLkaOCu--9xg" id="(0.5181818181818182,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEPobkEeWLkaOCu--9xg" id="(0.5523809523809524,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qpCEP4bkEeWLkaOCu--9xg" type="4001" source="_qpCChobkEeWLkaOCu--9xg" target="_qpCAYYbkEeWLkaOCu--9xg">
       <children xmi:type="notation:DecorationNode" xmi:id="_qpCEQIbkEeWLkaOCu--9xg" type="6001">
@@ -5464,8 +5398,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_qpCETIbkEeWLkaOCu--9xg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_YyfoEGkJEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCETYbkEeWLkaOCu--9xg" points="[7, 20, 0, -90]$[19, 86, 12, -24]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCETobkEeWLkaOCu--9xg" id="(0.5,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCET4bkEeWLkaOCu--9xg" id="(0.573170731707317,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCETobkEeWLkaOCu--9xg" id="(0.49523809523809526,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCET4bkEeWLkaOCu--9xg" id="(0.5548780487804879,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qpCEUIbkEeWLkaOCu--9xg" type="4001" source="_qpB_A4bkEeWLkaOCu--9xg" target="_qpCBS4bkEeWLkaOCu--9xg">
       <children xmi:type="notation:DecorationNode" xmi:id="_qpCEUYbkEeWLkaOCu--9xg" type="6001">
@@ -5513,9 +5447,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_qpCEbobkEeWLkaOCu--9xg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_Zb5MoH5NEeWWkJKpap4S3A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCEb4bkEeWLkaOCu--9xg" points="[0, 0, -85, 1]$[-11, 34, -96, 35]$[94, 34, 9, 35]$[94, -1, 9, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEcIbkEeWLkaOCu--9xg" id="(0.7639751552795031,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEcYbkEeWLkaOCu--9xg" id="(0.23870967741935484,1.0)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qpCEb4bkEeWLkaOCu--9xg" points="[0, 0, -119, 1]$[0, 34, -119, 35]$[119, 34, 0, 35]$[119, -1, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEcIbkEeWLkaOCu--9xg" id="(0.7575757575757576,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qpCEcYbkEeWLkaOCu--9xg" id="(0.13548387096774195,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_qpCEcobkEeWLkaOCu--9xg" type="StereotypeCommentLink" target="_qpCC1IbkEeWLkaOCu--9xg">
       <styles xmi:type="notation:FontStyle" xmi:id="_qpCEc4bkEeWLkaOCu--9xg"/>
@@ -5546,7 +5480,7 @@
       <element xmi:type="uml:Usage" href="TapiModule.uml#_ZfU2cIblEeWLkaOCu--9xg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZfencoblEeWLkaOCu--9xg" points="[0, 0, -228, 109]$[0, -118, -228, -9]$[228, -118, 0, -9]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zg0EMIblEeWLkaOCu--9xg" id="(0.5,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zg0EMYblEeWLkaOCu--9xg" id="(0.0,0.39344262295081966)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Zg0EMYblEeWLkaOCu--9xg" id="(0.0,0.14754098360655737)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_WKGxoYbmEeWLkaOCu--9xg" type="4007" source="_N-JSQIblEeWLkaOCu--9xg" target="_qpCA_YbkEeWLkaOCu--9xg">
       <children xmi:type="notation:DecorationNode" xmi:id="_WKGxpIbmEeWLkaOCu--9xg" type="6016">
@@ -5583,7 +5517,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_KrPsMobnEeWLkaOCu--9xg"/>
       <element xmi:type="uml:Usage" href="TapiModule.uml#_KrPsMIbnEeWLkaOCu--9xg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KrPsM4bnEeWLkaOCu--9xg" points="[0, 0, -201, -369]$[0, 360, -201, -9]$[201, 360, 0, -9]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_KrPsM4bnEeWLkaOCu--9xg" points="[0, 0, -201, -369]$[0, 369, -201, 0]$[201, 369, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KsSOAIbnEeWLkaOCu--9xg" id="(0.6055555555555555,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_KsSOAYbnEeWLkaOCu--9xg" id="(0.0,0.8548387096774194)"/>
     </edges>
@@ -5634,7 +5568,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_cho0EYbpEeWLkaOCu--9xg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_cfZ_cIbpEeWLkaOCu--9xg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cho0EobpEeWLkaOCu--9xg" points="[0, 0, 59, 0]$[0, 38, 59, 38]$[-66, 38, -7, 38]$[-66, 0, -7, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cho0EobpEeWLkaOCu--9xg" points="[0, 0, 48, 0]$[0, 38, 48, 38]$[-48, 38, 0, 38]$[-48, 0, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cihk4IbpEeWLkaOCu--9xg" id="(0.422360248447205,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cihk4YbpEeWLkaOCu--9xg" id="(0.055900621118012424,1.0)"/>
     </edges>
@@ -6783,7 +6717,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_9MEhIp1FEeWJ0fWjnLbawA" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_9MEhI51FEeWJ0fWjnLbawA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_9MEhJJ1FEeWJ0fWjnLbawA" x="3" y="-4"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9MEhJJ1FEeWJ0fWjnLbawA" x="18" y="-5"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_9MEhJZ1FEeWJ0fWjnLbawA" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_9MEhJp1FEeWJ0fWjnLbawA" y="-20"/>
@@ -6850,7 +6784,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_9MEio51FEeWJ0fWjnLbawA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_YyfoEGkJEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9MEipJ1FEeWJ0fWjnLbawA" points="[7, 20, 0, -90]$[19, 86, 12, -24]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEipZ1FEeWJ0fWjnLbawA" id="(0.45454545454545453,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEipZ1FEeWJ0fWjnLbawA" id="(0.4857142857142857,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEipp1FEeWJ0fWjnLbawA" id="(0.4695121951219512,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_9MEiqJ1FEeWJ0fWjnLbawA" type="4001" source="_9MEhk51FEeWJ0fWjnLbawA" target="_9MEhyJ1FEeWJ0fWjnLbawA">
@@ -6875,8 +6809,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_9MEitZ1FEeWJ0fWjnLbawA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9MEitp1FEeWJ0fWjnLbawA" points="[4, 52, 0, -98]$[7, 130, 3, -20]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEit51FEeWJ0fWjnLbawA" id="(0.5,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEiuJ1FEeWJ0fWjnLbawA" id="(0.5,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEit51FEeWJ0fWjnLbawA" id="(0.4817073170731707,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEiuJ1FEeWJ0fWjnLbawA" id="(0.49523809523809526,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_9MEjIZ1FEeWJ0fWjnLbawA" type="4001" source="_9MEhMp1FEeWJ0fWjnLbawA" target="_9MEjN51FEeWJ0fWjnLbawA">
       <children xmi:type="notation:DecorationNode" xmi:id="_9MEjIp1FEeWJ0fWjnLbawA" type="6001">
@@ -6906,15 +6840,15 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_9MEjMp1FEeWJ0fWjnLbawA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_nttnAGkFEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9MEjM51FEeWJ0fWjnLbawA" points="[2, 23, 0, -71]$[3, 71, 1, -23]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEjNJ1FEeWJ0fWjnLbawA" id="(0.5633802816901409,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEjNZ1FEeWJ0fWjnLbawA" id="(0.5111111111111111,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEjNJ1FEeWJ0fWjnLbawA" id="(0.4788732394366197,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9MEjNZ1FEeWJ0fWjnLbawA" id="(0.5094339622641509,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_9MEjaZ1FEeWJ0fWjnLbawA" type="4001" source="_9MEhMp1FEeWJ0fWjnLbawA" target="_9MEi751FEeWJ0fWjnLbawA">
       <children xmi:type="notation:DecorationNode" xmi:id="_9MEjap1FEeWJ0fWjnLbawA" type="6001">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_9MEja51FEeWJ0fWjnLbawA" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_9MEjbJ1FEeWJ0fWjnLbawA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_9MEjbZ1FEeWJ0fWjnLbawA" x="-23" y="-16"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9MEjbZ1FEeWJ0fWjnLbawA" x="-11" y="-13"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_9MEjbp1FEeWJ0fWjnLbawA" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_9MEjb51FEeWJ0fWjnLbawA" y="-20"/>
@@ -7026,8 +6960,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_T8AAUZ1HEeWJ0fWjnLbawA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_tQQ4UGj_EeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_T8AAUp1HEeWJ0fWjnLbawA" points="[-21, -52, 199, 501]$[-220, -553, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T8AAU51HEeWJ0fWjnLbawA" id="(0.15555555555555556,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T8AAVJ1HEeWJ0fWjnLbawA" id="(0.46218487394957986,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T8AAU51HEeWJ0fWjnLbawA" id="(0.15311004784688995,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_T8AAVJ1HEeWJ0fWjnLbawA" id="(0.4957983193277311,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_T8AAjZ1HEeWJ0fWjnLbawA" type="4001" source="_T8ABBp1HEeWJ0fWjnLbawA" target="_T8AAVp1HEeWJ0fWjnLbawA">
       <children xmi:type="notation:DecorationNode" xmi:id="_T8AAjp1HEeWJ0fWjnLbawA" type="6001">
@@ -7285,7 +7219,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_zLhXIZ1HEeWJ0fWjnLbawA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_B3JLoEHCEeWqPKyD1j6LMg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zLhXIp1HEeWJ0fWjnLbawA" points="[0, 0, 195, 142]$[0, -142, 195, 0]$[-195, -142, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zLhXIp1HEeWJ0fWjnLbawA" points="[0, 0, 166, 148]$[0, -148, 166, 0]$[-166, -148, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0mRd4J1HEeWJ0fWjnLbawA" id="(0.937888198757764,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_0nBEwJ1HEeWJ0fWjnLbawA" id="(1.0,0.40350877192982454)"/>
     </edges>
@@ -7319,7 +7253,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_-pHb1J1HEeWJ0fWjnLbawA" y="-20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_-pHb1Z1HEeWJ0fWjnLbawA" type="6002">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_-pHb1p1HEeWJ0fWjnLbawA" x="-26" y="-11"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_-pHb1p1HEeWJ0fWjnLbawA" x="-47" y="8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_-pHb151HEeWJ0fWjnLbawA" visible="false" type="6003">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_-pHb2J1HEeWJ0fWjnLbawA" y="-20"/>
@@ -7341,7 +7275,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_-pHb0Z1HEeWJ0fWjnLbawA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_Zb5MoH5NEeWWkJKpap4S3A"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-pHb0p1HEeWJ0fWjnLbawA" points="[0, 7, -167, -124]$[167, 7, 0, -124]$[167, 131, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-pHb0p1HEeWJ0fWjnLbawA" points="[0, 0, -144, -131]$[144, 0, 0, -131]$[144, 131, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ttFUJ1HEeWJ0fWjnLbawA" id="(1.0,0.7017543859649122)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__tQZYJ1HEeWJ0fWjnLbawA" id="(0.7701863354037267,0.0)"/>
     </edges>
@@ -7879,9 +7813,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_uIJfsZ1OEeWJ0fWjnLbawA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_niJd8GkKEeWZEqTYAF8eqA"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uIJfsp1OEeWJ0fWjnLbawA" points="[0, -3, 161, 828]$[69, -3, 230, 828]$[69, -831, 230, 0]$[-161, -831, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qZE1ELoaEeWgnN4av0rtYw" id="(1.0,0.15625)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qZE1EboaEeWgnN4av0rtYw" id="(1.0,0.11320754716981132)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_uIJfsp1OEeWJ0fWjnLbawA" points="[0, 0, 161, 836]$[69, 0, 230, 836]$[69, -835, 230, 1]$[-161, -836, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qZE1ELoaEeWgnN4av0rtYw" id="(1.0,0.40625)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qZE1EboaEeWgnN4av0rtYw" id="(1.0,0.32075471698113206)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_7WhlgJ1OEeWJ0fWjnLbawA" type="4005" source="_9MEi751FEeWJ0fWjnLbawA" target="_BaL_0J1JEeWJ0fWjnLbawA">
       <children xmi:type="notation:DecorationNode" xmi:id="_7Whlg51OEeWJ0fWjnLbawA" type="6012">
@@ -7927,7 +7861,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_E6muYZ1QEeWJ0fWjnLbawA"/>
       <element xmi:type="uml:Association" href="CoreModel.uml#_oGqoD1LNEeO75dO39GbF8Q"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E6muYp1QEeWJ0fWjnLbawA" points="[7, 0, -12, -116]$[7, -32, -12, -148]$[99, -32, 80, -148]$[99, 153, 80, 37]$[19, 153, 0, 37]$[19, 116, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E6muYp1QEeWJ0fWjnLbawA" points="[0, 0, -19, -116]$[0, -32, -19, -148]$[99, -32, 80, -148]$[99, 153, 80, 37]$[19, 153, 0, 37]$[19, 116, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NgxS8J1QEeWJ0fWjnLbawA" id="(0.7967479674796748,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NgLdEJ1QEeWJ0fWjnLbawA" id="(0.9512195121951219,1.0)"/>
     </edges>
@@ -7998,7 +7932,7 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_hgG5wZ1REeWJ0fWjnLbawA"/>
       <element xmi:type="uml:Association" href="CoreModel.uml#_i7cIUFYfEeOVGaP4lO41SQ"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hgG5wp1REeWJ0fWjnLbawA" points="[9, 0, -12, 12]$[9, 41, -12, 53]$[84, 41, 63, 53]$[84, -12, 63, 0]$[21, -12, 0, 0]"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_hgG5wp1REeWJ0fWjnLbawA" points="[0, 0, -21, 12]$[0, 41, -21, 53]$[84, 41, 63, 53]$[84, -12, 63, 0]$[21, -12, 0, 0]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nk_0YJ1REeWJ0fWjnLbawA" id="(0.8432835820895522,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nlvbQJ1REeWJ0fWjnLbawA" id="(1.0,0.8260869565217391)"/>
     </edges>
@@ -8281,7 +8215,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_49MtMboXEeWgnN4av0rtYw"/>
       <element xmi:type="uml:Realization" href="TapiModule.uml#_49C8MLoXEeWgnN4av0rtYw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_49MtMroXEeWgnN4av0rtYw" points="[-17, -8, 375, 0]$[-354, -8, 38, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Aw-kLoXEeWgnN4av0rtYw" id="(0.0,0.5686274509803921)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Aw-kLoXEeWgnN4av0rtYw" id="(0.0,0.43137254901960786)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5Aw-kboXEeWgnN4av0rtYw" id="(1.0,0.5)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_6le5qLoXEeWgnN4av0rtYw" type="StereotypeCommentLink" source="_49MtMLoXEeWgnN4av0rtYw" target="_6le5pLoXEeWgnN4av0rtYw">
@@ -8303,8 +8237,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_BeVAwboYEeWgnN4av0rtYw"/>
       <element xmi:type="uml:Realization" href="TapiModule.uml#_BeLPwLoYEeWgnN4av0rtYw"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BeVAwroYEeWgnN4av0rtYw" points="[0, -7, 336, -7]$[-54, -7, 282, -7]$[-336, -7, 0, -7]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bio5ALoYEeWgnN4av0rtYw" id="(0.0,0.8846153846153846)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BeVAwroYEeWgnN4av0rtYw" points="[0, 0, 336, -14]$[-336, 14, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bio5ALoYEeWgnN4av0rtYw" id="(0.0,0.75)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Bio5AboYEeWgnN4av0rtYw" id="(1.0,0.07758620689655173)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_CtMnp7oYEeWgnN4av0rtYw" type="StereotypeCommentLink" source="_BeVAwLoYEeWgnN4av0rtYw" target="_CtMno7oYEeWgnN4av0rtYw">
@@ -8683,8 +8617,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_N7KTEbpTEeWadf5Yweab7g"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_IzuHYKf4EeW6jfwWQNiYcg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_N7KTErpTEeWadf5Yweab7g" points="[0, -7, -20, 348]$[13, -7, -7, 348]$[62, -7, 42, 348]$[62, -355, 42, 0]$[20, -355, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U2jX4LpTEeWadf5Yweab7g" id="(1.0,0.19298245614035087)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_N7KTErpTEeWadf5Yweab7g" points="[0, 0, -20, 346]$[62, 0, 42, 346]$[62, -346, 42, 0]$[20, -346, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U2jX4LpTEeWadf5Yweab7g" id="(1.0,0.03508771929824561)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_U3vDoLpTEeWadf5Yweab7g" id="(1.0,0.8679245283018868)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_FVQ-0bpUEeWadf5Yweab7g" type="4005" source="_N7KTELpTEeWadf5Yweab7g" target="_y6xTcJ1JEeWJ0fWjnLbawA">
@@ -9319,7 +9253,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ULR8OaIBEeWqgMj1FXPlrA"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ULR8WKIBEeWqgMj1FXPlrA" x="60" y="552" height="73"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ULR8WKIBEeWqgMj1FXPlrA" x="90" y="533" height="73"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_ULR8WaIBEeWqgMj1FXPlrA" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_ULR8WqIBEeWqgMj1FXPlrA" showTitle="true"/>
@@ -9808,7 +9742,7 @@
       <element xmi:type="uml:Association" href="TapiModule.uml#_4Es8MGkIEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ULR_GqIBEeWqgMj1FXPlrA" points="[4, 52, 0, -98]$[7, 130, 3, -20]"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULR_G6IBEeWqgMj1FXPlrA" id="(0.5186813186813187,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULR_HKIBEeWqgMj1FXPlrA" id="(0.7641129032258065,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULR_HKIBEeWqgMj1FXPlrA" id="(0.7629310344827587,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ULR_HaIBEeWqgMj1FXPlrA" type="4001" source="_ULR8J6IBEeWqgMj1FXPlrA" target="_ULR6U6IBEeWqgMj1FXPlrA">
       <children xmi:type="notation:DecorationNode" xmi:id="_ULR_HqIBEeWqgMj1FXPlrA" type="6001">
@@ -9824,7 +9758,7 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ULR_JaIBEeWqgMj1FXPlrA" y="20"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_ULR_JqIBEeWqgMj1FXPlrA" type="6033">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ULR_J6IBEeWqgMj1FXPlrA" x="12" y="-13"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ULR_J6IBEeWqgMj1FXPlrA" x="27" y="-8"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_ULR_KKIBEeWqgMj1FXPlrA" type="6034">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_ULR_KaIBEeWqgMj1FXPlrA" x="-10" y="-21"/>
@@ -9832,7 +9766,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_ULR_KqIBEeWqgMj1FXPlrA"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_YyfoEGkJEeWZEqTYAF8eqA"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ULR_K6IBEeWqgMj1FXPlrA" points="[7, 20, 0, -90]$[19, 86, 12, -24]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULR_LKIBEeWqgMj1FXPlrA" id="(0.469061876247505,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULR_LKIBEeWqgMj1FXPlrA" id="(0.46551724137931033,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ULR_LaIBEeWqgMj1FXPlrA" id="(0.5524861878453039,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_ULR_LqIBEeWqgMj1FXPlrA" type="4001" source="_ULR5YaIBEeWqgMj1FXPlrA" target="_ULR7PaIBEeWqgMj1FXPlrA">
@@ -10331,7 +10265,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G3jIEd6SEeWd9KDn6x5Skg"/>
       </children>
       <element xmi:type="uml:Interface" href="TapiModule.uml#_5ASPgN6MEeWd9KDn6x5Skg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G3ZXAd6SEeWd9KDn6x5Skg" x="-26" y="13" height="109"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_G3ZXAd6SEeWd9KDn6x5Skg" x="74" y="6" height="109"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_G32C_t6SEeWd9KDn6x5Skg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_G32C_96SEeWd9KDn6x5Skg" showTitle="true"/>
@@ -10351,10 +10285,6 @@
           <element xmi:type="uml:Property" href="TapiModule.uml#_eMyr8t6ZEeWd9KDn6x5Skg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_1Fyc8d6ZEeWd9KDn6x5Skg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_2MUAIN6ZEeWd9KDn6x5Skg" type="3012">
-          <element xmi:type="uml:Property" href="TapiModule.uml#_KNiZ8N5yEeWd9KDn6x5Skg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_2MUAId6ZEeWd9KDn6x5Skg"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_apgPlt6SEeWd9KDn6x5Skg" showTitle="true"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_apgPl96SEeWd9KDn6x5Skg"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_apgPmN6SEeWd9KDn6x5Skg"/>
@@ -10373,7 +10303,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_apgPo96SEeWd9KDn6x5Skg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_apgPkd6SEeWd9KDn6x5Skg" x="543" y="209" height="93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_apgPkd6SEeWd9KDn6x5Skg" x="464" y="169" height="93"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_appZkt6SEeWd9KDn6x5Skg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_appZk96SEeWd9KDn6x5Skg" showTitle="true"/>
@@ -10419,7 +10349,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n0UrI96SEeWd9KDn6x5Skg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_BnjHcN5lEeWd9KDn6x5Skg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n0UrEd6SEeWd9KDn6x5Skg" x="581" y="374" width="430" height="108"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n0UrEd6SEeWd9KDn6x5Skg" x="339" y="328" width="198" height="108"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_n0d1Et6SEeWd9KDn6x5Skg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_n0d1E96SEeWd9KDn6x5Skg" showTitle="true"/>
@@ -10502,6 +10432,132 @@
       </styles>
       <element xsi:nil="true"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Yb3zFN6VEeWd9KDn6x5Skg" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_el5e8O_xEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_el5e8u_xEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_el5e8-_xEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_el5e9O_xEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_el5e9e_xEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_el5e9u_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_el5e9-_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_el5e-O_xEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_el5e-e_xEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_el5e-u_xEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_el5e--_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_el5e_O_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_el5e_e_xEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_el5e_u_xEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_el5e_-_xEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_el5fAO_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_el5fAe_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_el5fAu_xEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_el5fA-_xEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_el5e8e_xEeWLlrwIF3w0vA" x="746" y="26"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_emDP8-_xEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_emDP9O_xEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emDP9u_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emDP9e_xEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gCxsoO_xEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gCxsou_xEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gCxso-_xEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gCxspO_xEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gCxspe_xEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gCxspu_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gCxsp-_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gCxsqO_xEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCxsqe_xEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gCxsqu_xEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gCxsq-_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gCxsrO_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gCxsre_xEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCxsru_xEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gCxsr-_xEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gCxssO_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gCxsse_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gCxssu_xEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCxss-_xEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gCxsoe_xEeWLlrwIF3w0vA" x="756" y="137"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gC62ou_xEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gC62o-_xEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gC62pe_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gC62pO_xEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_g9Gm4O_xEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_g9Gm4u_xEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_g9Gm4-_xEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_g9Gm5O_xEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_g9Gm5e_xEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_g9Gm5u_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_g9Gm5-_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_g9Gm6O_xEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g9Gm6e_xEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_g9Gm6u_xEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_g9Gm6-_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_g9Gm7O_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_g9Gm7e_xEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g9Gm7u_xEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_g9Gm7-_xEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_g9Gm8O_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_g9Gm8e_xEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_g9Gm8u_xEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g9Gm8-_xEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g9Gm4e_xEeWLlrwIF3w0vA" x="748" y="277"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_g9QX8u_xEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_g9QX8-_xEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g9QX9e_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_g9QX9O_xEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_9zUkQ-_xEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_9zUkRO_xEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9zUkRu_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9zUkRe_xEeWLlrwIF3w0vA" x="722" y="77"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_-ykaw-_xEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_-ykaxO_xEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-ykaxu_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_-ykaxe_xEeWLlrwIF3w0vA" x="722" y="77"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ATRYg-_yEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ATRYhO_yEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ATRYhu_yEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ATRYhe_yEeWLlrwIF3w0vA" x="664" y="69"/>
     </children>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_3uHJI96REeWd9KDn6x5Skg"/>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_3uHJJN6REeWd9KDn6x5Skg" name="diagram_compatibility_version" stringValue="1.1.0"/>
@@ -10773,7 +10829,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_iQ9MUd6WEeWd9KDn6x5Skg"/>
       <element xmi:type="uml:Usage" href="TapiModule.uml#_iQzbUN6WEeWd9KDn6x5Skg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_iQ9MUt6WEeWd9KDn6x5Skg" points="[-1, 14, 10, -556]$[-9, 563, 2, -7]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iRszMN6WEeWd9KDn6x5Skg" id="(0.17366548042704627,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iRszMN6WEeWd9KDn6x5Skg" id="(0.16883116883116883,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iRszMd6WEeWd9KDn6x5Skg" id="(0.5798319327731093,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_yPynkN6WEeWd9KDn6x5Skg" type="4007" source="_G3ZXAN6SEeWd9KDn6x5Skg" target="_3uHD496REeWd9KDn6x5Skg">
@@ -10786,7 +10842,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_yPynkd6WEeWd9KDn6x5Skg"/>
       <element xmi:type="uml:Usage" href="TapiModule.uml#_yPo2kN6WEeWd9KDn6x5Skg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yPynkt6WEeWd9KDn6x5Skg" points="[-2, 11, 0, -67]$[-2, 55, 0, -23]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yQ1JYN6WEeWd9KDn6x5Skg" id="(0.050533807829181494,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yQ1JYN6WEeWd9KDn6x5Skg" id="(0.045454545454545456,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yQ1JYd6WEeWd9KDn6x5Skg" id="(0.49640287769784175,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_cTLJ0d6XEeWd9KDn6x5Skg" type="4007" source="_G3ZXAN6SEeWd9KDn6x5Skg" target="_apgPkN6SEeWd9KDn6x5Skg">
@@ -10799,8 +10855,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_cTLJ0t6XEeWd9KDn6x5Skg"/>
       <element xmi:type="uml:Usage" href="TapiModule.uml#_cTLJ0N6XEeWd9KDn6x5Skg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cTLJ096XEeWd9KDn6x5Skg" points="[8, 14, 0, -125]$[6, 134, -2, -5]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cUXcoN6XEeWd9KDn6x5Skg" id="(0.44555160142348754,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cUXcod6XEeWd9KDn6x5Skg" id="(0.12723214285714285,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cUXcoN6XEeWd9KDn6x5Skg" id="(0.44155844155844154,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cUXcod6XEeWd9KDn6x5Skg" id="(0.12318840579710146,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_jme_YN6XEeWd9KDn6x5Skg" type="4007" source="_G3ZXAN6SEeWd9KDn6x5Skg" target="_apgPkN6SEeWd9KDn6x5Skg">
       <children xmi:type="notation:DecorationNode" xmi:id="_jme_Y96XEeWd9KDn6x5Skg" type="6016">
@@ -10812,8 +10868,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_jme_Yd6XEeWd9KDn6x5Skg"/>
       <element xmi:type="uml:Usage" href="TapiModule.uml#_jmVOYN6XEeWd9KDn6x5Skg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jme_Yt6XEeWd9KDn6x5Skg" points="[1, 14, 0, -126]$[15, 134, 14, -6]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jnOmQN6XEeWd9KDn6x5Skg" id="(0.6519572953736655,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jnOmQd6XEeWd9KDn6x5Skg" id="(0.7745535714285714,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jnOmQN6XEeWd9KDn6x5Skg" id="(0.6493506493506493,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jnOmQd6XEeWd9KDn6x5Skg" id="(0.7681159420289855,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_x0GUoN6XEeWd9KDn6x5Skg" type="4001" source="_3uHEVd6REeWd9KDn6x5Skg" target="_3uHDsd6REeWd9KDn6x5Skg">
       <children xmi:type="notation:DecorationNode" xmi:id="_x0GUo96XEeWd9KDn6x5Skg" type="6001">
@@ -10865,7 +10921,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_-PmzEd6XEeWd9KDn6x5Skg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_-NFDgN6XEeWd9KDn6x5Skg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-PmzEt6XEeWd9KDn6x5Skg" points="[0, 7, 38, -214]$[-38, 7, 0, -214]$[-38, 221, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-QzF4N6XEeWd9KDn6x5Skg" id="(0.0,0.75)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-QzF4N6XEeWd9KDn6x5Skg" id="(0.030303030303030304,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-QzF4d6XEeWd9KDn6x5Skg" id="(0.171875,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_iG60oN6YEeWd9KDn6x5Skg" type="4001" source="_n0UrEN6SEeWd9KDn6x5Skg" target="_3uHDsd6REeWd9KDn6x5Skg">
@@ -10915,7 +10971,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_3Y918d6YEeWd9KDn6x5Skg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_3VGpoN6YEeWd9KDn6x5Skg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3Y918t6YEeWd9KDn6x5Skg" points="[2, 9, 0, -55]$[1, 61, -1, -3]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aT5wN6YEeWd9KDn6x5Skg" id="(0.4884393063583815,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aT5wN6YEeWd9KDn6x5Skg" id="(0.48484848484848486,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3aT5wd6YEeWd9KDn6x5Skg" id="(0.41964285714285715,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_eNFm4N6ZEeWd9KDn6x5Skg" type="4001" source="_apgPkN6SEeWd9KDn6x5Skg" target="_n0UrEN6SEeWd9KDn6x5Skg">
@@ -10940,8 +10996,143 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_eNFm4d6ZEeWd9KDn6x5Skg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_eMpiAN6ZEeWd9KDn6x5Skg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eNFm4t6ZEeWd9KDn6x5Skg" points="[0, 0, 14, -72]$[-14, 72, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eOk0oN6ZEeWd9KDn6x5Skg" id="(0.5223214285714286,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eOk0od6ZEeWd9KDn6x5Skg" id="(0.4558139534883721,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eOk0oN6ZEeWd9KDn6x5Skg" id="(0.5217391304347826,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eOk0od6ZEeWd9KDn6x5Skg" id="(0.45454545454545453,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_emDP9-_xEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_el5e8O_xEeWLlrwIF3w0vA" target="_emDP8-_xEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_emDP-O_xEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emDP_O_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_emDP-e_xEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emDP-u_xEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emDP--_xEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gC62pu_xEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_gCxsoO_xEeWLlrwIF3w0vA" target="_gC62ou_xEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gC62p-_xEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gC62q-_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_kJjOAO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gC62qO_xEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gC62qe_xEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gC62qu_xEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_g9QX9u_xEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_g9Gm4O_xEeWLlrwIF3w0vA" target="_g9QX8u_xEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_g9QX9-_xEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_g9QX--_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_PK97QO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_g9QX-O_xEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g9QX-e_xEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_g9QX-u_xEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ivOEwO_xEeWLlrwIF3w0vA" type="4001" source="_apgPkN6SEeWd9KDn6x5Skg" target="_el5e8O_xEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ivOEw-_xEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ivOExO_xEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ivOExe_xEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ivOExu_xEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ivOEx-_xEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ivOEyO_xEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ivOEye_xEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ivOEyu_xEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ivOEy-_xEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ivOEzO_xEeWLlrwIF3w0vA" x="20" y="-11"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ivOEze_xEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ivOEzu_xEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ivOEwe_xEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ivOEwu_xEeWLlrwIF3w0vA" points="[0, 0, -253, 97]$[224, -95, -29, 2]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iwQmkO_xEeWLlrwIF3w0vA" id="(0.9347826086956522,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_iwQmke_xEeWLlrwIF3w0vA" id="(0.0,0.76)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_jVBggO_xEeWLlrwIF3w0vA" type="4001" source="_apgPkN6SEeWd9KDn6x5Skg" target="_gCxsoO_xEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_jVBgg-_xEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jVBghO_xEeWLlrwIF3w0vA" x="1" y="2"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jVBghe_xEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jVBghu_xEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jVBgh-_xEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jVBgiO_xEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jVBgie_xEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jVBgiu_xEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jVBgi-_xEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jVBgjO_xEeWLlrwIF3w0vA" x="11" y="-16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jVBgje_xEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jVBgju_xEeWLlrwIF3w0vA" x="-10" y="-22"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_jVBgge_xEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jVBggu_xEeWLlrwIF3w0vA" points="[16, -5, -114, 35]$[112, -41, -18, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jWECUO_xEeWLlrwIF3w0vA" id="(1.0,0.4731182795698925)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_jWECUe_xEeWLlrwIF3w0vA" id="(0.0,0.54)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_jzOfcO_xEeWLlrwIF3w0vA" type="4001" source="_apgPkN6SEeWd9KDn6x5Skg" target="_g9Gm4O_xEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_jzOfc-_xEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jzOfdO_xEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jzOfde_xEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jzOfdu_xEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jzOfd-_xEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jzOfeO_xEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jzOfee_xEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jzOfeu_xEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jzOfe-_xEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jzOffO_xEeWLlrwIF3w0vA" x="25" y="17"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_jzOffe_xEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_jzOffu_xEeWLlrwIF3w0vA" x="-11" y="12"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_jzOfce_xEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_jzOfcu_xEeWLlrwIF3w0vA" points="[18, 7, -114, -51]$[102, 60, -30, 2]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_j0RBQO_xEeWLlrwIF3w0vA" id="(1.0,0.8064516129032258)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_j0RBQe_xEeWLlrwIF3w0vA" id="(0.0,0.41)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9zUkR-_xEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_ivOEwO_xEeWLlrwIF3w0vA" target="_9zUkQ-_xEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_9zUkSO_xEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_9zUkTO_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_iuK74O_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9zUkSe_xEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9zUkSu_xEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9zUkS-_xEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_-ykax-_xEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_jVBggO_xEeWLlrwIF3w0vA" target="_-ykaw-_xEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_-ykayO_xEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_-ykazO_xEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_jUIIoO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-ykaye_xEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-ykayu_xEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-ykay-_xEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ATRYh-_yEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_jzOfcO_xEeWLlrwIF3w0vA" target="_ATRYg-_yEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ATRYiO_yEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ATRYjO_yEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_jyVHkO_xEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ATRYie_yEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ATRYiu_yEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ATRYi-_yEeWLlrwIF3w0vA"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_BbuPgN71EeW-BtRsuJPbqg" type="PapyrusUMLClassDiagram" name="Link Details" measurementUnit="Pixel">
@@ -11141,7 +11332,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuRAt71EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZXM9yKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuRId71EeW-BtRsuJPbqg" x="327" y="39" height="121"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuRId71EeW-BtRsuJPbqg" x="142" y="46" height="121"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BbuRIt71EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BbuRI971EeW-BtRsuJPbqg" showTitle="true"/>
@@ -11182,7 +11373,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuRad71EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZW8dyKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuRiN71EeW-BtRsuJPbqg" x="326" y="182" height="77"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuRiN71EeW-BtRsuJPbqg" x="143" y="186" height="77"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BbuRid71EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BbuRit71EeW-BtRsuJPbqg" showTitle="true"/>
@@ -11240,7 +11431,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuSQd71EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZXGdyKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuSYN71EeW-BtRsuJPbqg" x="324" y="278" height="156"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuSYN71EeW-BtRsuJPbqg" x="146" y="283" height="156"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BbuSYd71EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BbuSYt71EeW-BtRsuJPbqg" showTitle="true"/>
@@ -11290,7 +11481,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuS6971EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZXB9yKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuTCt71EeW-BtRsuJPbqg" x="328" y="459" height="126"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuTCt71EeW-BtRsuJPbqg" x="150" y="468" height="126"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BbuTC971EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BbuTDN71EeW-BtRsuJPbqg" showTitle="true"/>
@@ -11328,7 +11519,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuTUN71EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZW99yKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuTb971EeW-BtRsuJPbqg" x="326" y="613" height="73"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuTb971EeW-BtRsuJPbqg" x="146" y="624" height="73"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BbuTcN71EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BbuTcd71EeW-BtRsuJPbqg" showTitle="true"/>
@@ -11366,7 +11557,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuTtd71EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZXXNyKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuT1N71EeW-BtRsuJPbqg" x="324" y="705" height="78"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuT1N71EeW-BtRsuJPbqg" x="146" y="731" height="78"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BbuT1d71EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BbuT1t71EeW-BtRsuJPbqg" showTitle="true"/>
@@ -11408,7 +11599,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuUMd71EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_KjZW_dyKEeWXdJnxZxtFYA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuUUN71EeW-BtRsuJPbqg" x="-330" y="702" height="94"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BbuUUN71EeW-BtRsuJPbqg" x="-360" y="726" height="94"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_BbuUUd71EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_BbuUUt71EeW-BtRsuJPbqg" showTitle="true"/>
@@ -11424,45 +11615,53 @@
         <layoutConstraint xmi:type="notation:Location" xmi:id="_FWRZhN71EeW-BtRsuJPbqg" y="5"/>
       </children>
       <children xmi:type="notation:BasicCompartment" xmi:id="_FWRZhd71EeW-BtRsuJPbqg" type="7017">
-        <children xmi:type="notation:Shape" xmi:id="_jM3NwN8AEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8PcO_jEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_LGsOI2kDEeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pce_jEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_nu8Pcu_jEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_8VW-oD-_EeWNAdBR30aJhw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pc-_jEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_nu8PdO_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_IZggA98AEeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_jM3Nwd8AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pde_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_lgcZ8N8AEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8Pdu_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_WSiGU971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_lgcZ8d8AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pd-_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_lgcZ8t8AEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8PeO_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_cQkyE971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_lgcZ898AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pee_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_lgcZ9N8AEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8Peu_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_gJx4Q971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_lgcZ9d8AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pe-_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_lgcZ9t8AEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8PfO_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_kZ4bg971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_lgcZ998AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pfe_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_lgcZ-N8AEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8Pfu_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_rJUvA971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_lgcZ-d8AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pf-_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_lgcZ-t8AEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8PgO_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#__ET2w971EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_lgcZ-98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pge_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_lgcZ_N8AEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8Pgu_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_CM28E972EeW-BtRsuJPbqg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_lgcZ_d8AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Pg-_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_bZ7VkN8DEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8PhO_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_37fFROMCEeSdZOEXoN8VDQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bZ7Vkd8DEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Phe_jEeWLlrwIF3w0vA"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_bZ7Vkt8DEeW-BtRsuJPbqg" type="3012">
+        <children xmi:type="notation:Shape" xmi:id="_nu8Phu_jEeWLlrwIF3w0vA" type="3012">
           <element xmi:type="uml:Property" href="TapiModule.uml#_QpQJIINtEeW35P6IpRw6Dg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_bZ7Vk98DEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_nu8Ph-_jEeWLlrwIF3w0vA"/>
         </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_FWRZht71EeW-BtRsuJPbqg" showTitle="true"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_FWRZh971EeW-BtRsuJPbqg"/>
@@ -11482,7 +11681,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FWRZk971EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FWRZgd71EeW-BtRsuJPbqg" x="-426" y="254" height="218"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FWRZgd71EeW-BtRsuJPbqg" x="-426" y="229" height="253"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_FWkUgt71EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_FWkUg971EeW-BtRsuJPbqg" showTitle="true"/>
@@ -11584,7 +11783,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_59xPQ97_EeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_59xPMd7_EeW-BtRsuJPbqg" x="-417" y="544" height="105"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_59xPMd7_EeW-BtRsuJPbqg" x="-418" y="580" height="105"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_5-EKMt7_EeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_5-EKM97_EeW-BtRsuJPbqg" showTitle="true"/>
@@ -11642,7 +11841,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e4fZI98BEeW-BtRsuJPbqg"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e4fZEd8BEeW-BtRsuJPbqg" x="-374" y="57" height="125"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e4fZEd8BEeW-BtRsuJPbqg" x="-392" y="46" height="125"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_e4yUA98BEeW-BtRsuJPbqg" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_e4yUBN8BEeW-BtRsuJPbqg" showTitle="true"/>
@@ -11971,8 +12170,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_WVM_0d71EeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_WSiGUN71EeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WVM_0t71EeW-BtRsuJPbqg" points="[0, 7, -289, 180]$[91, 7, -198, 180]$[91, -173, -198, 0]$[289, -173, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WWGXsN71EeW-BtRsuJPbqg" id="(1.0,0.05699481865284974)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WVM_0t71EeW-BtRsuJPbqg" points="[0, 0, -272, 142]$[85, 0, -187, 142]$[85, -142, -187, 0]$[272, -142, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WWGXsN71EeW-BtRsuJPbqg" id="(1.0,0.05504587155963303)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WWGXsd71EeW-BtRsuJPbqg" id="(0.0,0.4462809917355372)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_cT_5gN71EeW-BtRsuJPbqg" type="4001" source="_FWRZgN71EeW-BtRsuJPbqg" target="_BbuRPt71EeW-BtRsuJPbqg">
@@ -11996,8 +12195,8 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_cT_5gd71EeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_cQkyEN71EeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cT_5gt71EeW-BtRsuJPbqg" points="[0, 0, -288, 99]$[157, 0, -131, 99]$[157, -105, -131, -6]$[288, -105, 0, -6]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cU5RYN71EeW-BtRsuJPbqg" id="(1.0,0.29533678756476683)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cT_5gt71EeW-BtRsuJPbqg" points="[0, 0, -273, 80]$[151, 0, -122, 80]$[151, -80, -122, 0]$[273, -80, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cU5RYN71EeW-BtRsuJPbqg" id="(1.0,0.29357798165137616)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cU5RYd71EeW-BtRsuJPbqg" id="(0.0,0.4805194805194805)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_gNMYoN71EeW-BtRsuJPbqg" type="4001" source="_FWRZgN71EeW-BtRsuJPbqg" target="_BbuRpd71EeW-BtRsuJPbqg">
@@ -12022,8 +12221,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_gNMYod71EeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_gJx4QN71EeW-BtRsuJPbqg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gNMYot71EeW-BtRsuJPbqg" points="[0, 0, -255, 0]$[255, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gN7_gN71EeW-BtRsuJPbqg" id="(1.0,0.42660550458715596)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gN7_gd71EeW-BtRsuJPbqg" id="(0.0,0.4423076923076923)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gN7_gN71EeW-BtRsuJPbqg" id="(1.0,0.43873517786561267)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gN7_gd71EeW-BtRsuJPbqg" id="(0.0,0.36538461538461536)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_kdwO4N71EeW-BtRsuJPbqg" type="4001" source="_FWRZgN71EeW-BtRsuJPbqg" target="_BbuSfd71EeW-BtRsuJPbqg">
       <children xmi:type="notation:DecorationNode" xmi:id="_kdwO4971EeW-BtRsuJPbqg" type="6001">
@@ -12046,13 +12245,13 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_kdwO4d71EeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_kZ4bgN71EeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kdwO4t71EeW-BtRsuJPbqg" points="[0, -7, -290, -120]$[156, -7, -134, -120]$[156, 107, -134, -6]$[290, 107, 0, -6]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_keo_sN71EeW-BtRsuJPbqg" id="(1.0,0.689119170984456)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kdwO4t71EeW-BtRsuJPbqg" points="[0, 0, -280, -136]$[152, 0, -128, -136]$[152, 135, -128, -1]$[280, 136, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_keo_sN71EeW-BtRsuJPbqg" id="(1.0,0.6376146788990825)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_keo_sd71EeW-BtRsuJPbqg" id="(0.0,0.4603174603174603)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_rMJZgN71EeW-BtRsuJPbqg" type="4001" source="_FWRZgN71EeW-BtRsuJPbqg" target="_BbuTJ971EeW-BtRsuJPbqg">
       <children xmi:type="notation:DecorationNode" xmi:id="_rMJZg971EeW-BtRsuJPbqg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_rMJZhN71EeW-BtRsuJPbqg" x="-41" y="-34"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_rMJZhN71EeW-BtRsuJPbqg" x="-13" y="-33"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_rMJZhd71EeW-BtRsuJPbqg" visible="false" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_rMJZht71EeW-BtRsuJPbqg" y="20"/>
@@ -12071,9 +12270,9 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="_rMJZgd71EeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_rJUvAN71EeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rMJZgt71EeW-BtRsuJPbqg" points="[0, 0, -288, -234]$[111, 0, -177, -234]$[111, 230, -177, -4]$[288, 230, 0, -4]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rNCxYN71EeW-BtRsuJPbqg" id="(1.0,0.7568807339449541)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rNCxYd71EeW-BtRsuJPbqg" id="(0.0,0.547945205479452)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rMJZgt71EeW-BtRsuJPbqg" points="[0, 0, -276, -228]$[106, 0, -170, -228]$[106, 225, -170, -3]$[276, 228, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rNCxYN71EeW-BtRsuJPbqg" id="(1.0,0.7549407114624506)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rNCxYd71EeW-BtRsuJPbqg" id="(0.0,0.3287671232876712)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="__HSSQN71EeW-BtRsuJPbqg" type="4001" source="_FWRZgN71EeW-BtRsuJPbqg" target="_BbuTjN71EeW-BtRsuJPbqg">
       <children xmi:type="notation:DecorationNode" xmi:id="__HSSQ971EeW-BtRsuJPbqg" type="6001">
@@ -12096,13 +12295,13 @@
       </children>
       <styles xmi:type="notation:FontStyle" xmi:id="__HSSQd71EeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#__ET2wN71EeW-BtRsuJPbqg"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__HSSQt71EeW-BtRsuJPbqg" points="[0, 0, -286, -277]$[64, 0, -222, -277]$[64, 271, -222, -6]$[286, 271, 0, -6]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ILqIN71EeW-BtRsuJPbqg" id="(1.0,0.9533678756476683)"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__HSSQt71EeW-BtRsuJPbqg" points="[0, 0, -276, -297]$[76, 0, -200, -297]$[76, 293, -200, -4]$[276, 297, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ILqIN71EeW-BtRsuJPbqg" id="(1.0,0.9495412844036697)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__ILqId71EeW-BtRsuJPbqg" id="(0.0,0.44871794871794873)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_CPsNoN72EeW-BtRsuJPbqg" type="4001" source="_FWRZgN71EeW-BtRsuJPbqg" target="_BbuT8d71EeW-BtRsuJPbqg">
       <children xmi:type="notation:DecorationNode" xmi:id="_CPsNo972EeW-BtRsuJPbqg" type="6001">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_CPsNpN72EeW-BtRsuJPbqg" x="61" y="-5"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_CPsNpN72EeW-BtRsuJPbqg" x="-42" y="1"/>
       </children>
       <children xmi:type="notation:DecorationNode" xmi:id="_CPsNpd72EeW-BtRsuJPbqg" visible="false" type="6002">
         <layoutConstraint xmi:type="notation:Location" xmi:id="_CPsNpt72EeW-BtRsuJPbqg" y="20"/>
@@ -12122,8 +12321,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_CPsNod72EeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_CM28EN72EeW-BtRsuJPbqg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_CPsNot72EeW-BtRsuJPbqg" points="[0, 0, 20, -328]$[-20, 328, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CQuvcN72EeW-BtRsuJPbqg" id="(0.9849137931034483,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CQuvcd72EeW-BtRsuJPbqg" id="(0.9002493765586035,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CQuvcN72EeW-BtRsuJPbqg" id="(0.9831081081081081,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_CQuvcd72EeW-BtRsuJPbqg" id="(0.8395522388059702,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_YgMbR972EeW-BtRsuJPbqg" type="StereotypeCommentLink" source="_WVM_0N71EeW-BtRsuJPbqg" target="_YgMbQ972EeW-BtRsuJPbqg">
       <styles xmi:type="notation:FontStyle" xmi:id="_YgMbSN72EeW-BtRsuJPbqg"/>
@@ -12227,8 +12426,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Ic7ncd8AEeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Association" href="TapiModule.uml#_IZggAN8AEeW-BtRsuJPbqg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ic7nct8AEeW-BtRsuJPbqg" points="[-13, 27, 25, -57]$[-21, 72, 17, -12]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IeREMN8AEeW-BtRsuJPbqg" id="(0.5129310344827587,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IeREMd8AEeW-BtRsuJPbqg" id="(0.5400943396226415,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IeREMN8AEeW-BtRsuJPbqg" id="(0.5101351351351351,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_IeREMd8AEeW-BtRsuJPbqg" id="(0.5381679389312977,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_cQeqeN8AEeW-BtRsuJPbqg" type="StereotypeCommentLink" source="_Ic7ncN8AEeW-BtRsuJPbqg" target="_cQeqdN8AEeW-BtRsuJPbqg">
       <styles xmi:type="notation:FontStyle" xmi:id="_cQeqed8AEeW-BtRsuJPbqg"/>
@@ -12257,11 +12456,11 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_kWQpUd8BEeW-BtRsuJPbqg"/>
       <element xmi:type="uml:Generalization" href="TapiModule.uml#_kS1h4N8BEeW-BtRsuJPbqg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kWQpUt8BEeW-BtRsuJPbqg" points="[4, -32, 0, 117]$[4, -129, 0, 20]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kX5BAN8BEeW-BtRsuJPbqg" id="(0.4849137931034483,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kX5BAN8BEeW-BtRsuJPbqg" id="(0.4831081081081081,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_kX5BAd8BEeW-BtRsuJPbqg" id="(0.5,1.0)"/>
     </edges>
   </notation:Diagram>
-  <notation:Diagram xmi:id="__F1tsN8qEeWT9tG0gGLRFw" type="PapyrusUMLClassDiagram" name="LocalComponents" measurementUnit="Pixel">
+  <notation:Diagram xmi:id="__F1tsN8qEeWT9tG0gGLRFw" type="PapyrusUMLClassDiagram" name="LocalClasses" measurementUnit="Pixel">
     <children xmi:type="notation:Shape" xmi:id="__95-IN8qEeWT9tG0gGLRFw" type="2008">
       <children xmi:type="notation:DecorationNode" xmi:id="__95-It8qEeWT9tG0gGLRFw" type="5029"/>
       <children xmi:type="notation:DecorationNode" xmi:id="__95-I98qEeWT9tG0gGLRFw" type="8510">
@@ -12290,7 +12489,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="__95-M98qEeWT9tG0gGLRFw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_UhrZoN8qEeWT9tG0gGLRFw"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__95-Id8qEeWT9tG0gGLRFw" x="501" y="201" height="82"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="__95-Id8qEeWT9tG0gGLRFw" x="394" y="196" height="82"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="__-el4N8qEeWT9tG0gGLRFw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="__-el4d8qEeWT9tG0gGLRFw" showTitle="true"/>
@@ -12310,10 +12509,6 @@
           <element xmi:type="uml:Property" href="TapiModule.uml#_p40DAEUeEeWEwNCluy4jrw"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_c75Xcd8rEeWT9tG0gGLRFw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_c75Xct8rEeWT9tG0gGLRFw" type="3012">
-          <element xmi:type="uml:Property" href="TapiModule.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_c75Xc98rEeWT9tG0gGLRFw"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_DZukxt8rEeWT9tG0gGLRFw" showTitle="true"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_DZukx98rEeWT9tG0gGLRFw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_DZukyN8rEeWT9tG0gGLRFw"/>
@@ -12332,7 +12527,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DZuk098rEeWT9tG0gGLRFw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_kkzTEEUbEeWKAbXi7_SowQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DZukwd8rEeWT9tG0gGLRFw" x="256" y="22" height="93"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DZukwd8rEeWT9tG0gGLRFw" x="257" y="39" height="77"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_DZ6yEt8rEeWT9tG0gGLRFw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_DZ6yE98rEeWT9tG0gGLRFw" showTitle="true"/>
@@ -12364,10 +12559,6 @@
           <element xmi:type="uml:Property" href="TapiModule.uml#_GU9nEN6MEeWd9KDn6x5Skg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_e1evRd8rEeWT9tG0gGLRFw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_e1evRt8rEeWT9tG0gGLRFw" type="3012">
-          <element xmi:type="uml:Property" href="TapiModule.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_e1evR98rEeWT9tG0gGLRFw"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_KqbyRt8rEeWT9tG0gGLRFw" showTitle="true"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_KqbyR98rEeWT9tG0gGLRFw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_KqbySN8rEeWT9tG0gGLRFw"/>
@@ -12386,7 +12577,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KqbyU98rEeWT9tG0gGLRFw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_MIWTIGh5EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KqbyQd8rEeWT9tG0gGLRFw" x="801" y="186" height="144"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KqbyQd8rEeWT9tG0gGLRFw" x="626" y="183" height="123"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_KquGI98rEeWT9tG0gGLRFw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_KquGJN8rEeWT9tG0gGLRFw" showTitle="true"/>
@@ -12414,10 +12605,6 @@
           <element xmi:type="uml:Property" href="TapiModule.uml#_7vdVA2h_EeWZEqTYAF8eqA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_ZoFdVd8rEeWT9tG0gGLRFw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_ZoFdVt8rEeWT9tG0gGLRFw" type="3012">
-          <element xmi:type="uml:Property" href="TapiModule.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_ZoFdV98rEeWT9tG0gGLRFw"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_M0nx5t8rEeWT9tG0gGLRFw" showTitle="true"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_M0nx598rEeWT9tG0gGLRFw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_M0nx6N8rEeWT9tG0gGLRFw"/>
@@ -12436,7 +12623,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M0nx898rEeWT9tG0gGLRFw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_7vdU8Gh_EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M0nx4d8rEeWT9tG0gGLRFw" x="805" y="26" height="129"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_M0nx4d8rEeWT9tG0gGLRFw" x="636" y="25" height="110"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_M0z_Mt8rEeWT9tG0gGLRFw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_M0z_M98rEeWT9tG0gGLRFw" showTitle="true"/>
@@ -12464,10 +12651,6 @@
           <element xmi:type="uml:Property" href="TapiModule.uml#_sIutK2h-EeWZEqTYAF8eqA"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_atUnFd8rEeWT9tG0gGLRFw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_atUnFt8rEeWT9tG0gGLRFw" type="3012">
-          <element xmi:type="uml:Property" href="TapiModule.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_atUnF98rEeWT9tG0gGLRFw"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_QLSLtt8rEeWT9tG0gGLRFw" showTitle="true"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_QLSLt98rEeWT9tG0gGLRFw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_QLSLuN8rEeWT9tG0gGLRFw"/>
@@ -12486,7 +12669,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QLSLw98rEeWT9tG0gGLRFw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_sIutIGh-EeWZEqTYAF8eqA"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QLSLsd8rEeWT9tG0gGLRFw" x="667" y="360" height="122"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QLSLsd8rEeWT9tG0gGLRFw" x="530" y="351" height="110"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_QLeZAt8rEeWT9tG0gGLRFw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_QLeZA98rEeWT9tG0gGLRFw" showTitle="true"/>
@@ -12514,10 +12697,6 @@
           <element xmi:type="uml:Property" href="TapiModule.uml#_3VPzkN6YEeWd9KDn6x5Skg"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_YkFptd8rEeWT9tG0gGLRFw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_YkFptt8rEeWT9tG0gGLRFw" type="3012">
-          <element xmi:type="uml:Property" href="TapiModule.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_YkFpt98rEeWT9tG0gGLRFw"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_THuutt8rEeWT9tG0gGLRFw" showTitle="true"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_THuut98rEeWT9tG0gGLRFw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_THuuuN8rEeWT9tG0gGLRFw"/>
@@ -12536,7 +12715,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_THuuw98rEeWT9tG0gGLRFw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_BnjHcN5lEeWd9KDn6x5Skg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_THuusd8rEeWT9tG0gGLRFw" x="196" y="350" height="122"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_THuusd8rEeWT9tG0gGLRFw" x="196" y="350" height="108"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_TH68At8rEeWT9tG0gGLRFw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_TH68A98rEeWT9tG0gGLRFw" showTitle="true"/>
@@ -12568,10 +12747,6 @@
           <element xmi:type="uml:Property" href="TapiModule.uml#_r01pI76nEeWRz-VHgA3LJQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_Fc79Od8sEeWT9tG0gGLRFw"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Fc79Ot8sEeWT9tG0gGLRFw" type="3012">
-          <element xmi:type="uml:Property" href="TapiModule.uml#_dlarAN8qEeWT9tG0gGLRFw"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Fc79O98sEeWT9tG0gGLRFw"/>
-        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_BdQblt8sEeWT9tG0gGLRFw" showTitle="true"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_BdQbl98sEeWT9tG0gGLRFw"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_BdQbmN8sEeWT9tG0gGLRFw"/>
@@ -12590,7 +12765,7 @@
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BdQbo98sEeWT9tG0gGLRFw"/>
       </children>
       <element xmi:type="uml:Class" href="TapiModule.uml#_r01pEL6nEeWRz-VHgA3LJQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BdQbkd8sEeWT9tG0gGLRFw" x="-4" y="166" height="147"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BdQbkd8sEeWT9tG0gGLRFw" x="32" y="178" height="123"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_Bdivgt8sEeWT9tG0gGLRFw" type="StereotypeComment">
       <styles xmi:type="notation:TitleStyle" xmi:id="_Bdivg98sEeWT9tG0gGLRFw" showTitle="true"/>
@@ -12633,8 +12808,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_HS6c0d8rEeWT9tG0gGLRFw"/>
       <element xmi:type="uml:Generalization" href="TapiModule.uml#_HOnysN8rEeWT9tG0gGLRFw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HS6c0t8rEeWT9tG0gGLRFw" points="[5, -8, -126, 113]$[5, -80, -126, 41]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HTS3UN8rEeWT9tG0gGLRFw" id="(0.4717741935483871,1.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HTY98N8rEeWT9tG0gGLRFw" id="(0.5680933852140078,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HTS3UN8rEeWT9tG0gGLRFw" id="(0.4669603524229075,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HTY98N8rEeWT9tG0gGLRFw" id="(0.5645161290322581,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_KquGJ98rEeWT9tG0gGLRFw" type="StereotypeCommentLink" source="_KqbyQN8rEeWT9tG0gGLRFw" target="_KquGI98rEeWT9tG0gGLRFw">
       <styles xmi:type="notation:FontStyle" xmi:id="_KquGKN8rEeWT9tG0gGLRFw"/>
@@ -12683,8 +12858,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_VNDccd8rEeWT9tG0gGLRFw"/>
       <element xmi:type="uml:Generalization" href="TapiModule.uml#_VMSncN8rEeWT9tG0gGLRFw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VNDcct8rEeWT9tG0gGLRFw" points="[-7, -11, 9, 110]$[-7, -80, 9, 41]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VNuK0N8rEeWT9tG0gGLRFw" id="(0.5874125874125874,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VNuK0d8rEeWT9tG0gGLRFw" id="(0.5408560311284046,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VNuK0N8rEeWT9tG0gGLRFw" id="(0.58125,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VNuK0d8rEeWT9tG0gGLRFw" id="(0.5403225806451613,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_V80sgN8rEeWT9tG0gGLRFw" type="4002" source="_M0nx4N8rEeWT9tG0gGLRFw" target="__95-IN8qEeWT9tG0gGLRFw">
       <children xmi:type="notation:DecorationNode" xmi:id="_V80sg98rEeWT9tG0gGLRFw" type="6007">
@@ -12693,8 +12868,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_V80sgd8rEeWT9tG0gGLRFw"/>
       <element xmi:type="uml:Generalization" href="TapiModule.uml#_V5Y-AN8rEeWT9tG0gGLRFw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_V80sgt8rEeWT9tG0gGLRFw" points="[31, -52, -158, 265]$[175, -308, -14, 9]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_V9ZUQN8rEeWT9tG0gGLRFw" id="(0.0,0.7751937984496124)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_V9ZUQd8rEeWT9tG0gGLRFw" id="(0.8054474708171206,0.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_V9ZUQN8rEeWT9tG0gGLRFw" id="(0.0,0.7727272727272727)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_V9ZUQd8rEeWT9tG0gGLRFw" id="(0.7983870967741935,0.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_W1kSYN8rEeWT9tG0gGLRFw" type="4002" source="_KqbyQN8rEeWT9tG0gGLRFw" target="__95-IN8qEeWT9tG0gGLRFw">
       <children xmi:type="notation:DecorationNode" xmi:id="_W1kSY98rEeWT9tG0gGLRFw" type="6007">
@@ -12703,7 +12878,7 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_W1kSYd8rEeWT9tG0gGLRFw"/>
       <element xmi:type="uml:Generalization" href="TapiModule.uml#_Wx2QAN8rEeWT9tG0gGLRFw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_W1kSYt8rEeWT9tG0gGLRFw" points="[-12, -52, 55, 261]$[-82, -303, -15, 10]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W2PAwN8rEeWT9tG0gGLRFw" id="(0.0,0.3819444444444444)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W2PAwN8rEeWT9tG0gGLRFw" id="(0.0,0.37398373983739835)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_W2PAwd8rEeWT9tG0gGLRFw" id="(1.0,0.4878048780487805)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Xda8kN8rEeWT9tG0gGLRFw" type="4002" source="_QLSLsN8rEeWT9tG0gGLRFw" target="__95-IN8qEeWT9tG0gGLRFw">
@@ -12713,8 +12888,8 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_Xda8kd8rEeWT9tG0gGLRFw"/>
       <element xmi:type="uml:Generalization" href="TapiModule.uml#_XaztcN8rEeWT9tG0gGLRFw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Xda8kt8rEeWT9tG0gGLRFw" points="[-13, -17, 187, 252]$[-174, -260, 26, 9]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xd5dsN8rEeWT9tG0gGLRFw" id="(0.31376975169300225,0.0)"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xd5dsd8rEeWT9tG0gGLRFw" id="(0.8015564202334631,1.0)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xd5dsN8rEeWT9tG0gGLRFw" id="(0.31316725978647686,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Xd5dsd8rEeWT9tG0gGLRFw" id="(0.7983870967741935,1.0)"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_Bdivht8sEeWT9tG0gGLRFw" type="StereotypeCommentLink" source="_BdQbkN8sEeWT9tG0gGLRFw" target="_Bdivgt8sEeWT9tG0gGLRFw">
       <styles xmi:type="notation:FontStyle" xmi:id="_Bdivh98sEeWT9tG0gGLRFw"/>
@@ -12733,8 +12908,1813 @@
       <styles xmi:type="notation:FontStyle" xmi:id="_D7R9Md8sEeWT9tG0gGLRFw"/>
       <element xmi:type="uml:Generalization" href="TapiModule.uml#_D65isN8sEeWT9tG0gGLRFw"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_D7R9Mt8sEeWT9tG0gGLRFw" points="[62, 7, -171, 0]$[212, 4, -21, -3]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D8I40N8sEeWT9tG0gGLRFw" id="(1.0,0.47619047619047616)"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D8I40N8sEeWT9tG0gGLRFw" id="(1.0,0.4715447154471545)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_D8I40d8sEeWT9tG0gGLRFw" id="(0.0,0.4268292682926829)"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_Ocb1wO-pEeWLlrwIF3w0vA" type="PapyrusUMLClassDiagram" name="GlobalClasses" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_gpYREO_aEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gpiCEO_aEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gpiCEe_aEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gpiCEu_aEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gpiCE-_aEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_ieoigO_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_xEvjm98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ieoige_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ieoigu_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_xEvjn98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ieoig-_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ieoihO_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_xEvjo98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ieoihe_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ieoihu_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_xEvjp98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_ieoih-_aEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gpiCFO_aEeWLlrwIF3w0vA" showTitle="true"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gpiCFe_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gpiCFu_aEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gpiCF-_aEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gpiCGO_aEeWLlrwIF3w0vA" visible="false" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gpiCGe_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gpiCGu_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gpiCG-_aEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gpiCHO_aEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gpiCHe_aEeWLlrwIF3w0vA" visible="false" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gpiCHu_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gpiCH-_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gpiCIO_aEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gpiCIe_aEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gpYREe_aEeWLlrwIF3w0vA" x="428" y="117" height="125"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gp09A-_aEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gp09BO_aEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gp09Bu_aEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gp09Be_aEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_q3VS0O_aEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_q3VS0u_aEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_q3VS0-_aEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_q3VS1O_aEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_q3VS1e_aEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_uiIJkO_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_Iz0OAKf4EeW6jfwWQNiYcg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uiIJke_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_uiIJku_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_T3VIQT_NEeWNAdBR30aJhw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uiIJk-_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_uiIJlO_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_T7gvkz_LEeWNAdBR30aJhw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uiIJle_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_uiIJlu_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_W9zh097-EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uiIJl-_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_uiIJmO_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_tOFAk97rEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uiIJme_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_uiIJmu_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_7DdfM97vEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uiIJm-_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_uiIJnO_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_lqLYA97wEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uiIJne_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_uiIJnu_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_kTBiY97xEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uiIJn-_aEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_uiIJoO_aEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_xImb1OK4EeSq5fATALSQkQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_uiIJoe_aEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_q3VS1u_aEeWLlrwIF3w0vA" showTitle="true"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_q3VS1-_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_q3VS2O_aEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q3VS2e_aEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_q3VS2u_aEeWLlrwIF3w0vA" visible="false" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_q3VS2-_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_q3VS3O_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_q3VS3e_aEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q3VS3u_aEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_q3VS3-_aEeWLlrwIF3w0vA" visible="false" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_q3VS4O_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_q3VS4e_aEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_q3VS4u_aEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q3VS4-_aEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q3VS0e_aEeWLlrwIF3w0vA" x="18" y="116" height="205"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_q3ec0u_aEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_q3ec0-_aEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_q3ec1e_aEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_q3ec1O_aEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NqyYwO_dEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_NqyYwu_dEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NqyYw-_dEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NqyYxO_dEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_NqyYxe_dEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_UChW4O_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_LGsOI2kDEeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UChW4e_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UChW4u_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_8VW-oD-_EeWNAdBR30aJhw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UChW4-_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UChW5O_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_IZggA98AEeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UChW5e_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UChW5u_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_WSiGU971EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UChW5-_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UChW6O_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_cQkyE971EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UChW6e_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UChW6u_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_gJx4Q971EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UChW6-_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UChW7O_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_kZ4bg971EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UChW7e_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UChW7u_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_rJUvA971EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UChW7-_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UChW8O_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#__ET2w971EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UChW8e_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UCrH4O_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_CM28E972EeW-BtRsuJPbqg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UCrH4e_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UCrH4u_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_37fFROMCEeSdZOEXoN8VDQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UCrH4-_dEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_UCrH5O_dEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_QpQJIINtEeW35P6IpRw6Dg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_UCrH5e_dEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_NqyYxu_dEeWLlrwIF3w0vA" showTitle="true"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_NqyYx-_dEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_NqyYyO_dEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NqyYye_dEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_NqyYyu_dEeWLlrwIF3w0vA" visible="false" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_NqyYy-_dEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_NqyYzO_dEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_NqyYze_dEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NqyYzu_dEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_NqyYz-_dEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_NqyY0O_dEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_NqyY0e_dEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_NqyY0u_dEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NqyY0-_dEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NqyYwe_dEeWLlrwIF3w0vA" x="14" y="335" height="256"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NqyY5u_dEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_NqyY5-_dEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NqyY6e_dEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NqyY6O_dEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_y3jC8O_gEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_y3jC8u_gEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_y3jC8-_gEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_y3jC9O_gEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_y3jC9e_gEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_2h3_oO_gEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_9-Bkkj_KEeWNAdBR30aJhw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2h3_oe_gEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2h3_ou_gEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_Gkdvkj_DEeWNAdBR30aJhw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2h3_o-_gEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_2h3_pO_gEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_ejyEhOKyEeSq5fATALSQkQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_2h3_pe_gEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_y3jC9u_gEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_y3jC9-_gEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_y3jC-O_gEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y3jC-e_gEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_y3jC-u_gEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_y3jC--_gEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_y3jC_O_gEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_y3jC_e_gEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y3jC_u_gEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_y3jC_-_gEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_y3jDAO_gEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_y3jDAe_gEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_y3jDAu_gEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y3jDA-_gEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y3jC8e_gEeWLlrwIF3w0vA" x="22" y="2" height="97"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_y3sM8u_gEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_y3sM8-_gEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_y3sM9e_gEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_y3sM9O_gEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MESiwO_iEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_MESiwu_iEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_MESiw-_iEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_MESixO_iEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MESixe_iEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_R7tpIO_iEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_7HFlY0HHEeWqPKyD1j6LMg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_R7tpIe_iEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MESixu_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MESix-_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MESiyO_iEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MESiye_iEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MESiyu_iEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MESiy-_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MESizO_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MESize_iEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MESizu_iEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_MESiz-_iEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_MESi0O_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_MESi0e_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_MESi0u_iEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MESi0-_iEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MESiwe_iEeWLlrwIF3w0vA" x="445" y="-3" height="69"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_MEcTw-_iEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_MEcTxO_iEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MEcTxu_iEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MEcTxe_iEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_eEupYO_iEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_eEupYu_iEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_eEupY-_iEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_eEupZO_iEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_eEupZe_iEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_BGlBkO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_4Es8M2kIEeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_BGlBke_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_BGlBku_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_4EtL4EUcEeWEwNCluy4jrw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_BGlBk-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_BGlBlO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_WFu44u_qEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_BGlBle_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_BGlBlu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_oP678-_rEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_BGlBl-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_BGlBmO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_nfDxo-_pEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_BGlBme_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_BGlBmu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_kuDzQ0HaEeWqPKyD1j6LMg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_BGlBm-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_BGlBnO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_caIFkNnlEeWIOYiRCk5bbQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_BGlBne_uEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_eEupZu_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_eEupZ-_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_eEupaO_iEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eEupae_iEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_eEupau_iEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_eEupa-_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_eEupbO_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_eEupbe_iEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eEupbu_iEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_eEupb-_iEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_eEupcO_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_eEupce_iEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_eEupcu_iEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eEupc-_iEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eEupYe_iEeWLlrwIF3w0vA" x="740" y="-6" height="163"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_eFBkX-_iEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eFBkYO_iEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eFBkYu_iEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eFBkYe_iEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_s6fKcO_nEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_s6fKcu_nEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_s6fKc-_nEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_s6fKdO_nEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_s6fKde_nEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_FLdMQO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_nttnA2kFEeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_FLdMQe_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_FLdMQu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_ZiYSAEUcEeWEwNCluy4jrw"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_FLdMQ-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_FLdMRO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_niJd9WkKEeWZEqTYAF8eqA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_FLdMRe_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_FLdMRu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_B0rIk-_sEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_FLdMR-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_FLdMSO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_IZ3vc0HbEeWqPKyD1j6LMg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_FLdMSe_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_FLdMSu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_V2I0INnlEeWIOYiRCk5bbQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_FLdMS-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_s6fKdu_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_s6fKd-_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_s6fKeO_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s6fKee_nEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_s6fKeu_nEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_s6fKe-_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_s6fKfO_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_s6fKfe_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s6fKfu_nEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_s6fKf-_nEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_s6fKgO_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_s6fKge_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_s6fKgu_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s6fKg-_nEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s6fKce_nEeWLlrwIF3w0vA" x="747" y="170" height="146"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_s6oUcu_nEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_s6oUc-_nEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_s6oUde_nEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s6oUdO_nEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_2wSx8O_nEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_2wSx8u_nEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_2wSx8-_nEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_2wSx9O_nEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_2wSx9e_nEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_LGQWwO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_0rYyYtnXEeWIOYiRCk5bbQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LGQWwe_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LGQWwu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_G1pfM9nfEeWIOYiRCk5bbQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LGQWw-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LGQWxO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_STzYA-_tEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LGQWxe_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_LGQWxu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_093zYKU7EeWkWNPM1BHzGA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LGQWx-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_2wSx9u_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_2wSx9-_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_2wSx-O_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2wSx-e_nEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_2wSx-u_nEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_2wSx--_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_2wSx_O_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_2wSx_e_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2wSx_u_nEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_2wSx_-_nEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_2wSyAO_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_2wSyAe_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_2wSyAu_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2wSyA-_nEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2wSx8e_nEeWLlrwIF3w0vA" x="301" y="476" height="114"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_2wcjAu_nEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_2wcjA-_nEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2wcjBe_nEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2wcjBO_nEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5vMzEO_nEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_5vMzEu_nEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_5vMzE-_nEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_5vMzFO_nEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5vMzFe_nEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_OnJDkO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_aFAUM9nYEeWIOYiRCk5bbQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OnJDke_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_OnJDku_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_MM7wMEHBEeWqPKyD1j6LMg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OnJDk-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_OnJDlO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_S3giA-_tEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OnJDle_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_OnJDlu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_9hsOkKU7EeWkWNPM1BHzGA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_OnJDl-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5vMzFu_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5vMzF-_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5vMzGO_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5vMzGe_nEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5vMzGu_nEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5vMzG-_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5vMzHO_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5vMzHe_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5vMzHu_nEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_5vMzH-_nEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_5vMzIO_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_5vMzIe_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_5vMzIu_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5vMzI-_nEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5vMzEe_nEeWLlrwIF3w0vA" x="400" y="337" height="108"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_5vMzNu_nEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_5vMzN-_nEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5vMzOe_nEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5vMzOO_nEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8FTu0O_nEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_8FTu0u_nEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_8FTu0-_nEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8FTu1O_nEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8FTu1e_nEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_T3j0UO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_hv9Ns9nYEeWIOYiRCk5bbQ"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T3j0Ue_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T3j0Uu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_Zb_6UH5NEeWWkJKpap4S3A"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T3j0U-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T3j0VO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_B3Ln4EHCEeWqPKyD1j6LMg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T3j0Ve_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T3j0Vu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_cfZ_c4bpEeWLkaOCu--9xg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T3j0V-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T3j0WO_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_TPT-A-_tEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T3j0We_uEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_T3j0Wu_uEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_6a7R8KU7EeWkWNPM1BHzGA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_T3j0W-_uEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_8FTu1u_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_8FTu1-_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_8FTu2O_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8FTu2e_nEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8FTu2u_nEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_8FTu2-_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_8FTu3O_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_8FTu3e_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8FTu3u_nEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_8FTu3-_nEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_8FTu4O_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_8FTu4e_nEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_8FTu4u_nEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8FTu4-_nEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8FTu0e_nEeWLlrwIF3w0vA" x="606" y="456" height="145"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_8Fmpx-_nEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_8FmpyO_nEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8Fmpyu_nEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8Fmpye_nEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UkIUgO_wEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UkIUgu_wEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_UkIUg-_wEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_UkIUhO_wEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_UkIUhe_wEeWLlrwIF3w0vA" type="7017">
+        <children xmi:type="notation:Shape" xmi:id="_TkFh4O_yEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_eMyr8t6ZEeWd9KDn6x5Skg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TkFh4e_yEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TkFh4u_yEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_iuK74-_xEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TkFh4-_yEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TkFh5O_yEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_jyVHk-_xEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TkFh5e_yEeWLlrwIF3w0vA"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_TkFh5u_yEeWLlrwIF3w0vA" type="3012">
+          <element xmi:type="uml:Property" href="TapiModule.uml#_jUIIo-_xEeWLlrwIF3w0vA"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_TkFh5-_yEeWLlrwIF3w0vA"/>
+        </children>
+        <styles xmi:type="notation:TitleStyle" xmi:id="_UkIUhu_wEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_UkIUh-_wEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_UkIUiO_wEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UkIUie_wEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_UkIUiu_wEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_UkIUi-_wEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_UkIUjO_wEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_UkIUje_wEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UkIUju_wEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_UkIUj-_wEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_UkIUkO_wEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_UkIUke_wEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_UkIUku_wEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UkIUk-_wEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UkIUge_wEeWLlrwIF3w0vA" x="703" y="332" height="107"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_UkSFku_wEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_UkSFk-_wEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UkSFle_wEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UkSFlO_wEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_Ocb1we-pEeWLlrwIF3w0vA" name="diagram_compatibility_version" stringValue="1.1.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_Ocb1wu-pEeWLlrwIF3w0vA"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_Ocb1w--pEeWLlrwIF3w0vA">
+      <owner xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_gp09B-_aEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_gpYREO_aEeWLlrwIF3w0vA" target="_gp09A-_aEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gp09CO_aEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gp09DO_aEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gp09Ce_aEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gp09Cu_aEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gp09C-_aEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_q3ec1u_aEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_q3VS0O_aEeWLlrwIF3w0vA" target="_q3ec0u_aEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_q3ec1-_aEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_q3ec2-_aEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_xImb0OK4EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_q3ec2O_aEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q3ec2e_aEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_q3ec2u_aEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_9TyAAO_aEeWLlrwIF3w0vA" type="4002" source="_q3VS0O_aEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_9TyAA-_aEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_9TyABO_aEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_9TyAAe_aEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_W9J6MN8BEeW-BtRsuJPbqg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9TyAAu_aEeWLlrwIF3w0vA" points="[0, 0, -104, 104]$[104, -104, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9TyABe_aEeWLlrwIF3w0vA" id="(1.0,0.4878048780487805)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9TyABu_aEeWLlrwIF3w0vA" id="(0.0,0.376)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NqyY6u_dEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_NqyYwO_dEeWLlrwIF3w0vA" target="_NqyY5u_dEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_NqyY6-_dEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NqyY7-_dEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_37fFQOMCEeSdZOEXoN8VDQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NqyY7O_dEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NqyY7e_dEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NqyY7u_dEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ViMZ4O_dEeWLlrwIF3w0vA" type="4002" source="_NqyYwO_dEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ViMZ4-_dEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ViMZ5O_dEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_ViMZ4e_dEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_kS1h4N8BEeW-BtRsuJPbqg"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ViMZ4u_dEeWLlrwIF3w0vA" points="[0, 0, 301, -18]$[-301, 18, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ViMZ5e_dEeWLlrwIF3w0vA" id="(1.0,0.16796875)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ViMZ5u_dEeWLlrwIF3w0vA" id="(0.0,0.784)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_y3sM9u_gEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_y3jC8O_gEeWLlrwIF3w0vA" target="_y3sM8u_gEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_y3sM9-_gEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_y3sM--_gEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_ejyEgOKyEeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_y3sM-O_gEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y3sM-e_gEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_y3sM-u_gEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_51tH4O_gEeWLlrwIF3w0vA" type="4002" source="_y3jC8O_gEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_51tH4-_gEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_51tH5O_gEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_51tH4e_gEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_5ybxcO_gEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_51tH4u_gEeWLlrwIF3w0vA" points="[32, 97, -10, -29]$[48, 114, 6, -12]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_52mfwO_gEeWLlrwIF3w0vA" id="(1.0,0.5463917525773195)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_52mfwe_gEeWLlrwIF3w0vA" id="(0.0,0.152)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_MEcTx-_iEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_MESiwO_iEeWLlrwIF3w0vA" target="_MEcTw-_iEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_MEcTyO_iEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_MEcTzO_iEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_sfccMOK0EeSq5fATALSQkQ"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_MEcTye_iEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MEcTyu_iEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_MEcTy-_iEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NtU9IO_iEeWLlrwIF3w0vA" type="4002" source="_MESiwO_iEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_NtU9I-_iEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NtU9JO_iEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_NtU9Ie_iEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_NqC_oO_iEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NtU9Iu_iEeWLlrwIF3w0vA" points="[19, 100, -10, -52]$[28, 149, -1, -3]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NuNt8O_iEeWLlrwIF3w0vA" id="(0.5057471264367817,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NuNt8e_iEeWLlrwIF3w0vA" id="(0.45789473684210524,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_eFBkY-_iEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_eEupYO_iEeWLlrwIF3w0vA" target="_eFBkX-_iEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eFBkZO_iEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eFBkaO_iEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eFBkZe_iEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eFBkZu_iEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eFBkZ-_iEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nvDAUO_nEeWLlrwIF3w0vA" type="4002" source="_eEupYO_iEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nvDAU-_nEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nvDAVO_nEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_nvDAUe_nEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_ntHGoO_nEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nvDAUu_nEeWLlrwIF3w0vA" points="[-19, 18, 56, -55]$[-60, 68, 15, -5]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nv8YMO_nEeWLlrwIF3w0vA" id="(0.0,0.5214723926380368)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nv8YMe_nEeWLlrwIF3w0vA" id="(1.0,0.192)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_s6oUdu_nEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_s6fKcO_nEeWLlrwIF3w0vA" target="_s6oUcu_nEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_s6oUd-_nEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_s6oUe-_nEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_s6oUeO_nEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s6oUee_nEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_s6oUeu_nEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tvJhkO_nEeWLlrwIF3w0vA" type="4002" source="_s6fKcO_nEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_tvJhk-_nEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_tvJhlO_nEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_tvJhke_nEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_ttEd8O_nEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tvJhku_nEeWLlrwIF3w0vA" points="[-17, -3, 101, 11]$[-90, -7, 28, 7]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tv5IcO_nEeWLlrwIF3w0vA" id="(0.0,0.589041095890411)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tv5Ice_nEeWLlrwIF3w0vA" id="(1.0,0.672)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_2wcjBu_nEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_2wSx8O_nEeWLlrwIF3w0vA" target="_2wcjAu_nEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_2wcjB-_nEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_2wcjC-_nEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_2wcjCO_nEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2wcjCe_nEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_2wcjCu_nEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_3xUxIO_nEeWLlrwIF3w0vA" type="4002" source="_2wSx8O_nEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_3xUxI-_nEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_3xUxJO_nEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_3xUxIe_nEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_3vF8gO_nEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_3xUxIu_nEeWLlrwIF3w0vA" points="[0, 0, -78, 85]$[76, -70, -2, 15]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3yNh8O_nEeWLlrwIF3w0vA" id="(0.16731517509727625,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_3yNh8e_nEeWLlrwIF3w0vA" id="(0.25263157894736843,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_5vMzOu_nEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_5vMzEO_nEeWLlrwIF3w0vA" target="_5vMzNu_nEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_5vMzO-_nEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_5vMzP-_nEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_5vMzPO_nEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5vMzPe_nEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_5vMzPu_nEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_6hnHcO_nEeWLlrwIF3w0vA" type="4002" source="_5vMzEO_nEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_6hnHc-_nEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6hnHdO_nEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_6hnHce_nEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_6frNwO_nEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6hnHcu_nEeWLlrwIF3w0vA" points="[-8, -21, 39, 103]$[-35, -107, 12, 17]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6ippQO_nEeWLlrwIF3w0vA" id="(0.4742647058823529,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6ippQe_nEeWLlrwIF3w0vA" id="(0.7052631578947368,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8Fmpy-_nEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_8FTu0O_nEeWLlrwIF3w0vA" target="_8Fmpx-_nEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_8FmpzO_nEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_8Fmp0O_nEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8Fmpze_nEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8Fmpzu_nEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8Fmpz-_nEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_8_CMIO_nEeWLlrwIF3w0vA" type="4002" source="_8FTu0O_nEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_8_CMI-_nEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_8_CMJO_nEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_8_CMIe_nEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_89GScO_nEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8_CMIu_nEeWLlrwIF3w0vA" points="[0, 0, 91, 96]$[-74, -84, 17, 12]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9AOe8O_nEeWLlrwIF3w0vA" id="(0.16339869281045752,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9AOe8e_nEeWLlrwIF3w0vA" id="(0.8947368421052632,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_UkSFlu_wEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_UkIUgO_wEeWLlrwIF3w0vA" target="_UkSFku_wEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_UkSFl-_wEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_UkSFm-_wEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_aMQ88N5xEeWd9KDn6x5Skg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_UkSFmO_wEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UkSFme_wEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_UkSFmu_wEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WKywUO_wEeWLlrwIF3w0vA" type="4002" source="_UkIUgO_wEeWLlrwIF3w0vA" target="_gpYREO_aEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_WKywU-_wEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WKywVO_wEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_WKywUe_wEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_WKDJcO_wEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WKywUu_wEeWLlrwIF3w0vA" points="[0, 0, 166, 108]$[-150, -100, 16, 8]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WMR-EO_wEeWLlrwIF3w0vA" id="(0.0,0.19626168224299065)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WMR-Ee_wEeWLlrwIF3w0vA" id="(1.0,0.944)"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_StKQAO_pEeWLlrwIF3w0vA" type="PapyrusUMLClassDiagram" name="Connectivity Details" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_e5eb4O_pEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_e5eb4u_pEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_e5eb4-_pEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_e5eb5O_pEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e5eb5e_pEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_e5eb5u_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_e5eb5-_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_e5eb6O_pEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e5eb6e_pEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e5eb6u_pEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_e5eb6-_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_e5eb7O_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_e5eb7e_pEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e5eb7u_pEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_e5eb7-_pEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_e5eb8O_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_e5eb8e_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_e5eb8u_pEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e5eb8-_pEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e5eb4e_pEeWLlrwIF3w0vA" x="99" y="222"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_e5oM4-_pEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_e5oM5O_pEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e5oM5u_pEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e5oM5e_pEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gwN7EO_pEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gwN7Eu_pEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_gwN7E-_pEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gwN7FO_pEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gwN7Fe_pEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gwN7Fu_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gwN7F-_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gwN7GO_pEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gwN7Ge_pEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gwN7Gu_pEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gwN7G-_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gwN7HO_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gwN7He_pEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gwN7Hu_pEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_gwN7H-_pEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_gwN7IO_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_gwN7Ie_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_gwN7Iu_pEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gwN7I-_pEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gwN7Ee_pEeWLlrwIF3w0vA" x="110" y="46"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_gwXsE-_pEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_gwXsFO_pEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gwXsFu_pEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gwXsFe_pEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_knThYO_pEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_knThYu_pEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_knThY-_pEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_knThZO_pEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_knThZe_pEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_knThZu_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_knThZ-_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_knThaO_pEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_knThae_pEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_knThau_pEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_knTha-_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_knThbO_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_knThbe_pEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_knThbu_pEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_knThb-_pEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_knThcO_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_knThce_pEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_knThcu_pEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_knThc-_pEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_knThYe_pEeWLlrwIF3w0vA" x="115" y="423"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_knnDY-_pEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_knnDZO_pEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_knnDZu_pEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_knnDZe_pEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_GeYwk-_qEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_GeYwlO_qEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GeYwlu_qEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_nfDxoO_pEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GeYwle_qEeWLlrwIF3w0vA" x="299" y="122"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VQKi0O_qEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_VQKi0u_qEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_VQKi0-_qEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_VQKi1O_qEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_VQKi1e_qEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_VQKi1u_qEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_VQKi1-_qEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_VQKi2O_qEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VQKi2e_qEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_VQKi2u_qEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_VQKi2-_qEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_VQKi3O_qEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_VQKi3e_qEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VQKi3u_qEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_VQKi3-_qEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_VQKi4O_qEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_VQKi4e_qEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_VQKi4u_qEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VQKi4-_qEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VQKi0e_qEeWLlrwIF3w0vA" x="351" y="160"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_VQUT4u_qEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_VQUT4-_qEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VQUT5e_qEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VQUT5O_qEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_b1QnhO_qEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_b1Qnhe_qEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_b1Qnh-_qEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b1Qnhu_qEeWLlrwIF3w0vA" x="299" y="122"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nXiicO_rEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_nXiicu_rEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_nXiic-_rEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_nXiidO_rEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_nXiide_rEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_nXiidu_rEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_nXiid-_rEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_nXiieO_rEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nXiiee_rEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_nXiieu_rEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_nXiie-_rEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_nXiifO_rEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_nXiife_rEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nXiifu_rEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_nXiif-_rEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_nXiigO_rEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_nXiige_rEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_nXiigu_rEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nXiig-_rEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nXiice_rEeWLlrwIF3w0vA" x="384" y="294"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_nXrscu_rEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nXrsc-_rEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nXrsde_rEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nXrsdO_rEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_zsGrY-_rEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_zsGrZO_rEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zsGrZu_rEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_oP678O_rEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zsGrZe_rEeWLlrwIF3w0vA" x="299" y="122"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_AtYwYO_sEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_AtYwYu_sEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_AtYwY-_sEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_AtYwZO_sEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AtYwZe_sEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AtYwZu_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AtYwZ-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AtYwaO_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AtYwae_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AtYwau_sEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AtYwa-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AtYwbO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AtYwbe_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AtYwbu_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_AtYwb-_sEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_AtYwcO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_AtYwce_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_AtYwcu_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AtYwc-_sEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AtYwYe_sEeWLlrwIF3w0vA" x="623" y="241"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Atihcu_sEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Atihc-_sEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Atihde_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AtihdO_sEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_HjlzM-_sEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_HjlzNO_sEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HjlzNu_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_B0rIkO_sEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HjlzNe_sEeWLlrwIF3w0vA" x="583" y="344"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NA_3EO_sEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_NA_3Eu_sEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_NA_3E-_sEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_NA_3FO_sEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_NA_3Fe_sEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_NA_3Fu_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_NA_3F-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_NA_3GO_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NA_3Ge_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_NA_3Gu_sEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_NA_3G-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_NA_3HO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_NA_3He_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NA_3Hu_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_NA_3H-_sEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_NA_3IO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_NA_3Ie_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_NA_3Iu_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NA_3I-_sEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NA_3Ee_sEeWLlrwIF3w0vA" x="610" y="446"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_NBJoIu_sEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_NBJoI-_sEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NBJoJe_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NBJoJO_sEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_StKQAe_pEeWLlrwIF3w0vA" name="diagram_compatibility_version" stringValue="1.1.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_StKQAu_pEeWLlrwIF3w0vA"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_StKQA-_pEeWLlrwIF3w0vA">
+      <owner xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_e5oM5-_pEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_e5eb4O_pEeWLlrwIF3w0vA" target="_e5oM4-_pEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_e5oM6O_pEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_e5oM7O_pEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_kuDzQEHaEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_e5oM6e_pEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e5oM6u_pEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e5oM6-_pEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gwXsF-_pEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_gwN7EO_pEeWLlrwIF3w0vA" target="_gwXsE-_pEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_gwXsGO_pEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_gwXsHO_pEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gwXsGe_pEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gwXsGu_pEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gwXsG-_pEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_irNoIO_pEeWLlrwIF3w0vA" type="4002" source="_e5eb4O_pEeWLlrwIF3w0vA" target="_gwN7EO_pEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_irNoI-_pEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_irNoJO_pEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_irNoIe_pEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_ntHGoO_nEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_irNoIu_pEeWLlrwIF3w0vA" points="[0, 0, -11, 176]$[11, -176, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_irNoJe_pEeWLlrwIF3w0vA" id="(0.4523809523809524,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_irNoJu_pEeWLlrwIF3w0vA" id="(0.5420560747663551,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_knnDZ-_pEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_knThYO_pEeWLlrwIF3w0vA" target="_knnDY-_pEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_knnDaO_pEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_knnDbO_pEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_knnDae_pEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_knnDau_pEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_knnDa-_pEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_niCNIO_pEeWLlrwIF3w0vA" type="4001" source="_e5eb4O_pEeWLlrwIF3w0vA" target="_knThYO_pEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_niCNI-_pEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_niCNJO_pEeWLlrwIF3w0vA" y="-10"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_niCNJe_pEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_niCNJu_pEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_niCNJ-_pEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_niCNKO_pEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_niCNKe_pEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_niCNKu_pEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_niCNK-_pEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_niCNLO_pEeWLlrwIF3w0vA" x="13" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_niCNLe_pEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_niCNLu_pEeWLlrwIF3w0vA" x="-11" y="18"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_niCNIe_pEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_nfDxoO_pEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_niCNIu_pEeWLlrwIF3w0vA" points="[-3, 20, 13, -114]$[-19, 121, -3, -13]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_niVIEu_pEeWLlrwIF3w0vA" id="(0.5952380952380952,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_niVIE-_pEeWLlrwIF3w0vA" id="(0.44761904761904764,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_GeYwl-_qEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_niCNIO_pEeWLlrwIF3w0vA" target="_GeYwk-_qEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_GeYwmO_qEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_GeYwnO_qEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_nfDxoO_pEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GeYwme_qEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GeYwmu_qEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GeYwm-_qEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_VQUT5u_qEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_VQKi0O_qEeWLlrwIF3w0vA" target="_VQUT4u_qEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_VQUT5-_qEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_VQUT6-_qEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_DOEi4O-IEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VQUT6O_qEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VQUT6e_qEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VQUT6u_qEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_WHz8gO_qEeWLlrwIF3w0vA" type="4001" source="_e5eb4O_pEeWLlrwIF3w0vA" target="_VQKi0O_qEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_WHz8g-_qEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WHz8hO_qEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WHz8he_qEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WHz8hu_qEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WHz8h-_qEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WHz8iO_qEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WHz8ie_qEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WHz8iu_qEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WHz8i-_qEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WHz8jO_qEeWLlrwIF3w0vA" x="6" y="12"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_WHz8je_qEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_WHz8ju_qEeWLlrwIF3w0vA" x="-20" y="14"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_WHz8ge_qEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_WHz8gu_qEeWLlrwIF3w0vA" points="[24, -1, -151, 1]$[163, -3, -12, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WIG3cu_qEeWLlrwIF3w0vA" id="(1.0,0.46)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_WIG3c-_qEeWLlrwIF3w0vA" id="(0.0,0.49)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_b1QniO_qEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_WHz8gO_qEeWLlrwIF3w0vA" target="_b1QnhO_qEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_b1Qnie_qEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_b1Qnje_qEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_WFlH4O_qEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_b1Qniu_qEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b1Qni-_qEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_b1QnjO_qEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_nXrsdu_rEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_nXiicO_rEeWLlrwIF3w0vA" target="_nXrscu_rEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nXrsd-_rEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nXrse-_rEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_rBq8YO-fEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nXrseO_rEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nXrsee_rEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nXrseu_rEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_oSJwkO_rEeWLlrwIF3w0vA" type="4001" source="_e5eb4O_pEeWLlrwIF3w0vA" target="_nXiicO_rEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_oSJwk-_rEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_oSJwlO_rEeWLlrwIF3w0vA" x="10" y="-3"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_oSJwle_rEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_oSJwlu_rEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_oSJwl-_rEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_oSJwmO_rEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_oSJwme_rEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_oSJwmu_rEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_oSJwm-_rEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_oSJwnO_rEeWLlrwIF3w0vA" x="16" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_oSJwne_rEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_oSJwnu_rEeWLlrwIF3w0vA" x="-12" y="11"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_oSJwke_rEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_oP678O_rEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_oSJwku_rEeWLlrwIF3w0vA" points="[27, 15, -161, -96]$[170, 113, -18, 2]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oSmcgO_rEeWLlrwIF3w0vA" id="(1.0,0.85)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_oSmcge_rEeWLlrwIF3w0vA" id="(0.0,0.44)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_zsGrZ-_rEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_oSJwkO_rEeWLlrwIF3w0vA" target="_zsGrY-_rEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_zsGraO_rEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_zsGrbO_rEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_oP678O_rEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_zsGrae_rEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zsGrau_rEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_zsGra-_rEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Atihdu_sEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_AtYwYO_sEeWLlrwIF3w0vA" target="_Atihcu_sEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Atihd-_sEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Atihe-_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_IZ3vcEHbEeWqPKyD1j6LMg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AtiheO_sEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Atihee_sEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Atiheu_sEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_B3qLIO_sEeWLlrwIF3w0vA" type="4001" source="_AtYwYO_sEeWLlrwIF3w0vA" target="_NA_3EO_sEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_B3qLI-_sEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_B3qLJO_sEeWLlrwIF3w0vA" x="-4" y="9"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_B3qLJe_sEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_B3qLJu_sEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_B3qLJ-_sEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_B3qLKO_sEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_B3qLKe_sEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_B3qLKu_sEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_B3qLK-_sEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_B3qLLO_sEeWLlrwIF3w0vA" x="17" y="-16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_B3qLLe_sEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_B3qLLu_sEeWLlrwIF3w0vA" x="-15" y="-19"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_B3qLIe_sEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_B0rIkO_sEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_B3qLIu_sEeWLlrwIF3w0vA" points="[-24, -2, 189, 9]$[-187, 4, 26, 15]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B4GQAO_sEeWLlrwIF3w0vA" id="(0.18095238095238095,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_B4GQAe_sEeWLlrwIF3w0vA" id="(0.5789473684210527,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HjlzN-_sEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_B3qLIO_sEeWLlrwIF3w0vA" target="_HjlzM-_sEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_HjlzOO_sEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_HjlzPO_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_B0rIkO_sEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HjlzOe_sEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HjlzOu_sEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HjlzO-_sEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_NBJoJu_sEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_NA_3EO_sEeWLlrwIF3w0vA" target="_NBJoIu_sEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_NBJoJ-_sEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_NBJoK-_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_NBJoKO_sEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NBJoKe_sEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_NBJoKu_sEeWLlrwIF3w0vA"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_bpPaMO_pEeWLlrwIF3w0vA" type="PapyrusUMLClassDiagram" name="EdgeEndPoint Details" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_Zk_jIO_sEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Zk_jIu_sEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Zk_jI-_sEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Zk_jJO_sEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Zk_jJe_sEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Zk_jJu_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Zk_jJ-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Zk_jKO_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zk_jKe_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Zk_jKu_sEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Zk_jK-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Zk_jLO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Zk_jLe_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zk_jLu_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_Zk_jL-_sEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_Zk_jMO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_Zk_jMe_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_Zk_jMu_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zk_jM-_sEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zk_jIe_sEeWLlrwIF3w0vA" x="251" y="203"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ZlItIu_sEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ZlItI-_sEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZlItJe_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZlItJO_sEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_abJIAO_sEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_abJIAu_sEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_abJIA-_sEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_abJIBO_sEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_abJIBe_sEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_abJIBu_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_abJIB-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_abJICO_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_abJICe_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_abJICu_sEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_abJIC-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_abJIDO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_abJIDe_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_abJIDu_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_abJID-_sEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_abJIEO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_abJIEe_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_abJIEu_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_abJIE-_sEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_abJIAe_sEeWLlrwIF3w0vA" x="402" y="43"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_abS5Eu_sEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_abS5E-_sEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_abS5Fe_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_abS5FO_sEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bP0GMO_sEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_bP0GMu_sEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_bP0GM-_sEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_bP0GNO_sEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bP0GNe_sEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bP0GNu_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bP0GN-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bP0GOO_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bP0GOe_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bP0GOu_sEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bP0GO-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bP0GPO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bP0GPe_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bP0GPu_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_bP0GP-_sEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_bP0GQO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_bP0GQe_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_bP0GQu_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bP0GQ-_sEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bP0GMe_sEeWLlrwIF3w0vA" x="392" y="197"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_bP9QMu_sEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_bP9QM-_sEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bP9QNe_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bP9QNO_sEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_cLBxQO_sEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_cLBxQu_sEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_cLBxQ-_sEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_cLBxRO_sEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_cLBxRe_sEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_cLBxRu_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_cLBxR-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_cLBxSO_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cLBxSe_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_cLBxSu_sEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_cLBxS-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_cLBxTO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_cLBxTe_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cLBxTu_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_cLBxT-_sEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_cLBxUO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_cLBxUe_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_cLBxUu_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cLBxU-_sEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cLBxQe_sEeWLlrwIF3w0vA" x="552" y="195"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_cLK7Qu_sEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_cLK7Q-_sEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cLK7Re_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cLK7RO_sEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mJvdIO_sEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_mJvdIu_sEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_mJvdI-_sEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_mJvdJO_sEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mJvdJe_sEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mJvdJu_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mJvdJ-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mJvdKO_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mJvdKe_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mJvdKu_sEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mJvdK-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mJvdLO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mJvdLe_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mJvdLu_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_mJvdL-_sEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_mJvdMO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_mJvdMe_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_mJvdMu_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mJvdM-_sEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mJvdIe_sEeWLlrwIF3w0vA" x="226" y="401"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_mKCYE-_sEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_mKCYFO_sEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mKCYFu_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mKCYFe_sEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ys3mgO_sEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_ys3mgu_sEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_ys3mg-_sEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_ys3mhO_sEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ys3mhe_sEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ys3mhu_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ys3mh-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ys3miO_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ys3mie_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ys3miu_sEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ys3mi-_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ys3mjO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ys3mje_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ys3mju_sEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_ys3mj-_sEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_ys3mkO_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_ys3mke_sEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_ys3mku_sEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ys3mk-_sEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ys3mge_sEeWLlrwIF3w0vA" x="570" y="394"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_ys3mpu_sEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ys3mp-_sEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ytAwcO_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ys3mqO_sEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_QwYdcO_tEeWLlrwIF3w0vA" type="2008">
+      <children xmi:type="notation:DecorationNode" xmi:id="_QwYdcu_tEeWLlrwIF3w0vA" type="5029"/>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QwYdc-_tEeWLlrwIF3w0vA" type="8510">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QwYddO_tEeWLlrwIF3w0vA" y="5"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QwYdde_tEeWLlrwIF3w0vA" type="7017">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QwYddu_tEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QwYdd-_tEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QwYdeO_tEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QwYdee_tEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QwYdeu_tEeWLlrwIF3w0vA" type="7018">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QwYde-_tEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QwYdfO_tEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QwYdfe_tEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QwYdfu_tEeWLlrwIF3w0vA"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_QwYdf-_tEeWLlrwIF3w0vA" type="7019">
+        <styles xmi:type="notation:TitleStyle" xmi:id="_QwYdgO_tEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:SortingStyle" xmi:id="_QwYdge_tEeWLlrwIF3w0vA"/>
+        <styles xmi:type="notation:FilteringStyle" xmi:id="_QwYdgu_tEeWLlrwIF3w0vA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QwYdg-_tEeWLlrwIF3w0vA"/>
+      </children>
+      <element xmi:type="uml:Class" href="TapiModule.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QwYdce_tEeWLlrwIF3w0vA" x="402" y="394"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_Qwhncu_tEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_Qwhnc-_tEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qwhnde_tEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QwhndO_tEeWLlrwIF3w0vA" x="200"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_rtqjRO_tEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_rtqjRe_tEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rtqjR-_tEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_STzYAO_tEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rtqjRu_tEeWLlrwIF3w0vA" x="446" y="146"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_smpZs-_tEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_smpZtO_tEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_smpZtu_tEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_S3giAO_tEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_smpZte_tEeWLlrwIF3w0vA" x="599" y="141"/>
+    </children>
+    <children xmi:type="notation:Shape" xmi:id="_tWuLw-_tEeWLlrwIF3w0vA" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_tWuLxO_tEeWLlrwIF3w0vA" showTitle="true"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWuLxu_tEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_TPT-AO_tEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_tWuLxe_tEeWLlrwIF3w0vA" x="763" y="141"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_bpPaMe_pEeWLlrwIF3w0vA" name="diagram_compatibility_version" stringValue="1.1.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_bpPaMu_pEeWLlrwIF3w0vA"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_bpPaM-_pEeWLlrwIF3w0vA">
+      <owner xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+    </styles>
+    <element xmi:type="uml:Package" href="TapiModule.uml#_AivIMOKxEeSq5fATALSQkQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_ZlItJu_sEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_Zk_jIO_sEeWLlrwIF3w0vA" target="_ZlItIu_sEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ZlItJ-_sEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ZlItK-_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_i1UzkD-3EeWNAdBR30aJhw"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZlItKO_sEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZlItKe_sEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ZlItKu_sEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_abS5Fu_sEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_abJIAO_sEeWLlrwIF3w0vA" target="_abS5Eu_sEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_abS5F-_sEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_abS5G-_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_xEvjkN8AEeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_abS5GO_sEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_abS5Ge_sEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_abS5Gu_sEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_bP9QNu_sEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_bP0GMO_sEeWLlrwIF3w0vA" target="_bP9QMu_sEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_bP9QN-_sEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_bP9QO-_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_It0sYEG-EeWMO5szP8dKiA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bP9QOO_sEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bP9QOe_sEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bP9QOu_sEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_cLK7Ru_sEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_cLBxQO_sEeWLlrwIF3w0vA" target="_cLK7Qu_sEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_cLK7R-_sEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_cLK7S-_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cLK7SO_sEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cLK7Se_sEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cLK7Su_sEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_c4i-kO_sEeWLlrwIF3w0vA" type="4002" source="_cLBxQO_sEeWLlrwIF3w0vA" target="_abJIAO_sEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_c4i-k-_sEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_c4i-lO_sEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_c4i-ke_sEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_89GScO_nEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_c4i-ku_sEeWLlrwIF3w0vA" points="[0, 0, 194, 190]$[-92, -90, 102, 100]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c4i-le_sEeWLlrwIF3w0vA" id="(0.0,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_c4i-lu_sEeWLlrwIF3w0vA" id="(1.0,0.96)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_dm0Z0O_sEeWLlrwIF3w0vA" type="4002" source="_Zk_jIO_sEeWLlrwIF3w0vA" target="_abJIAO_sEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_dm0Z0-_sEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_dm0Z1O_sEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_dm0Z0e_sEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_3vF8gO_nEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dm0Z0u_sEeWLlrwIF3w0vA" points="[0, 0, -232, 195]$[232, -195, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dm0Z1e_sEeWLlrwIF3w0vA" id="(0.6666666666666666,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dm0Z1u_sEeWLlrwIF3w0vA" id="(0.1588785046728972,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_gBQb8O_sEeWLlrwIF3w0vA" type="4002" source="_bP0GMO_sEeWLlrwIF3w0vA" target="_abJIAO_sEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_gBQb8-_sEeWLlrwIF3w0vA" type="6007">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_gBQb9O_sEeWLlrwIF3w0vA" y="40"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_gBQb8e_sEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Generalization" href="TapiModule.uml#_6frNwO_nEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_gBQb8u_sEeWLlrwIF3w0vA" points="[0, 0, -27, 192]$[27, -192, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gBQb9e_sEeWLlrwIF3w0vA" id="(0.5700934579439252,0.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_gBQb9u_sEeWLlrwIF3w0vA" id="(0.45794392523364486,1.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_mKCYF-_sEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_mJvdIO_sEeWLlrwIF3w0vA" target="_mKCYE-_sEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_mKCYGO_sEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_mKCYHO_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_j2GU0N78EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mKCYGe_sEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mKCYGu_sEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mKCYG-_sEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ytAwce_sEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_ys3mgO_sEeWLlrwIF3w0vA" target="_ys3mpu_sEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ytAwcu_sEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ytAwdu_sEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_TlA2gN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ytAwc-_sEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ytAwdO_sEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ytAwde_sEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Qwhndu_tEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_QwYdcO_tEeWLlrwIF3w0vA" target="_Qwhncu_tEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_Qwhnd-_tEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_Qwhne-_tEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Class" href="TapiModule.uml#_oJg1UN79EeW-BtRsuJPbqg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QwhneO_tEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qwhnee_tEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Qwhneu_tEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_SXOfcO_tEeWLlrwIF3w0vA" type="4001" source="_Zk_jIO_sEeWLlrwIF3w0vA" target="_mJvdIO_sEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_SXOfc-_tEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SXOfdO_tEeWLlrwIF3w0vA" x="-7" y="-13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SXOfde_tEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SXOfdu_tEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SXOfd-_tEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SXOfeO_tEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SXOfee_tEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SXOfeu_tEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SXOfe-_tEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SXOffO_tEeWLlrwIF3w0vA" x="9" y="-15"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_SXOffe_tEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_SXOffu_tEeWLlrwIF3w0vA" x="-19" y="-17"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_SXOfce_tEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_STzYAO_tEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_SXOfcu_tEeWLlrwIF3w0vA" points="[-10, 24, 28, -74]$[-46, 79, -8, -19]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SXqkUO_tEeWLlrwIF3w0vA" id="(0.45714285714285713,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_SXqkUe_tEeWLlrwIF3w0vA" id="(0.44761904761904764,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_S54gkO_tEeWLlrwIF3w0vA" type="4001" source="_bP0GMO_sEeWLlrwIF3w0vA" target="_QwYdcO_tEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_S54gk-_tEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S54glO_tEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_S54gle_tEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S54glu_tEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_S54gl-_tEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S54gmO_tEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_S54gme_tEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S54gmu_tEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_S54gm-_tEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S54gnO_tEeWLlrwIF3w0vA" x="14" y="19"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_S54gne_tEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_S54gnu_tEeWLlrwIF3w0vA" x="-13" y="20"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_S54gke_tEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_S3giAO_tEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_S54gku_tEeWLlrwIF3w0vA" points="[33, 100, -25, -75]$[56, 153, -2, -22]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S6VMgO_tEeWLlrwIF3w0vA" id="(0.6074766355140186,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_S6VMge_tEeWLlrwIF3w0vA" id="(0.5,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_TRiyoO_tEeWLlrwIF3w0vA" type="4001" source="_cLBxQO_sEeWLlrwIF3w0vA" target="_ys3mgO_sEeWLlrwIF3w0vA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_TRiyo-_tEeWLlrwIF3w0vA" type="6001">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TRiypO_tEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_TRiype_tEeWLlrwIF3w0vA" visible="false" type="6002">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TRiypu_tEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_TRiyp-_tEeWLlrwIF3w0vA" visible="false" type="6003">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TRiyqO_tEeWLlrwIF3w0vA" y="-20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_TRiyqe_tEeWLlrwIF3w0vA" visible="false" type="6005">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TRiyqu_tEeWLlrwIF3w0vA" y="20"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_TRiyq-_tEeWLlrwIF3w0vA" type="6033">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TRiyrO_tEeWLlrwIF3w0vA" x="9" y="13"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_TRiyre_tEeWLlrwIF3w0vA" type="6034">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_TRiyru_tEeWLlrwIF3w0vA" x="-12" y="13"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_TRiyoe_tEeWLlrwIF3w0vA"/>
+      <element xmi:type="uml:Association" href="TapiModule.uml#_TPT-AO_tEeWLlrwIF3w0vA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_TRiyou_tEeWLlrwIF3w0vA" points="[47, 100, -36, -74]$[89, 153, 6, -21]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TSbjcO_tEeWLlrwIF3w0vA" id="(0.5984848484848485,1.0)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_TSbjce_tEeWLlrwIF3w0vA" id="(0.556390977443609,0.0)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_rtqjSO_tEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_SXOfcO_tEeWLlrwIF3w0vA" target="_rtqjRO_tEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_rtqjSe_tEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_rtqjTe_tEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_STzYAO_tEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rtqjSu_tEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rtqjS-_tEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rtqjTO_tEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_smpZt-_tEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_S54gkO_tEeWLlrwIF3w0vA" target="_smpZs-_tEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_smpZuO_tEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_smpZvO_tEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_S3giAO_tEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_smpZue_tEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_smpZuu_tEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_smpZu-_tEeWLlrwIF3w0vA"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_tWuLx-_tEeWLlrwIF3w0vA" type="StereotypeCommentLink" source="_TRiyoO_tEeWLlrwIF3w0vA" target="_tWuLw-_tEeWLlrwIF3w0vA">
+      <styles xmi:type="notation:FontStyle" xmi:id="_tWuLyO_tEeWLlrwIF3w0vA"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_tWuLzO_tEeWLlrwIF3w0vA" name="BASE_ELEMENT">
+        <eObjectValue xmi:type="uml:Association" href="TapiModule.uml#_TPT-AO_tEeWLlrwIF3w0vA"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tWuLye_tEeWLlrwIF3w0vA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWuLyu_tEeWLlrwIF3w0vA"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tWuLy-_tEeWLlrwIF3w0vA"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/TransportAPI/UML/TapiModule.uml
+++ b/TransportAPI/UML/TapiModule.uml
@@ -12,6 +12,7 @@
           <body>The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. &#xD;
 At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). </body>
         </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_5ybxcO_gEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_9-Bkkj_KEeWNAdBR30aJhw" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" aggregation="composite" association="_9-A9gD_KEeWNAdBR30aJhw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JhtDID_LEeWNAdBR30aJhw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Jhu4UD_LEeWNAdBR30aJhw" value="*"/>
@@ -19,36 +20,6 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
         <ownedAttribute xmi:type="uml:Property" xmi:id="_Gkdvkj_DEeWNAdBR30aJhw" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" aggregation="composite" association="_GkchcD_DEeWNAdBR30aJhw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kX5jID_DEeWNAdBR30aJhw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kX7YUD_DEeWNAdBR30aJhw" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ONRbcL3wEeWxDaRqnNJFbQ" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_ONRbcb3wEeWxDaRqnNJFbQ" annotatedElement="_ONRbcL3wEeWxDaRqnNJFbQ">
-            <body>UUID: An identifier that is universally unique&#xD;
-&#xD;
-(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ONRbcr3wEeWxDaRqnNJFbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ONRbc73wEeWxDaRqnNJFbQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_EtDQ4L6JEeWRz-VHgA3LJQ" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_yk5WsL6eEeWRz-VHgA3LJQ" annotatedElement="_JhEg4L6GEeWRz-VHgA3LJQ">
-            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_EtDQ476JEeWRz-VHgA3LJQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_EtDQ5L6JEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_mbbFcL6IEeWRz-VHgA3LJQ" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_sBnFUL6dEeWRz-VHgA3LJQ" annotatedElement="_XfLagb6GEeWRz-VHgA3LJQ">
-            <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mbbFc76IEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_mbbFdL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_C5o9EL6KEeWRz-VHgA3LJQ" name="extension" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_jHacYL6bEeWRz-VHgA3LJQ" annotatedElement="_fzRiML6HEeWRz-VHgA3LJQ">
-            <body>List of simple name-value extentions. Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_C5o9E76KEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_C5o9FL6KEeWRz-VHgA3LJQ" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ejyEhOKyEeSq5fATALSQkQ" name="layerProtocolName" visibility="public" type="_i92HIL6PEeWRz-VHgA3LJQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ejyEheKyEeSq5fATALSQkQ" value="1"/>
@@ -59,39 +30,10 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
         <ownedComment xmi:type="uml:Comment" xmi:id="_sfccMeK0EeSq5fATALSQkQ">
           <body>The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).</body>
         </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_NqC_oO_iEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_7HFlY0HHEeWqPKyD1j6LMg" name="_topology" type="_ejyEgOKyEeSq5fATALSQkQ" aggregation="composite" association="_7HFlYEHHEeWqPKyD1j6LMg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_FeLVAEHIEeWqPKyD1j6LMg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FeNKMEHIEeWqPKyD1j6LMg" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Dke30L3wEeWxDaRqnNJFbQ" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_Dke30b3wEeWxDaRqnNJFbQ" annotatedElement="_Dke30L3wEeWxDaRqnNJFbQ">
-            <body>UUID: An identifier that is universally unique&#xD;
-&#xD;
-(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Dke30r3wEeWxDaRqnNJFbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Dke3073wEeWxDaRqnNJFbQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_s8ygsL6IEeWRz-VHgA3LJQ" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_ldDWsL6eEeWRz-VHgA3LJQ" annotatedElement="_JhEg4L6GEeWRz-VHgA3LJQ">
-            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_s8ygs76IEeWRz-VHgA3LJQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_s8ygtL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_fPK6IL6IEeWRz-VHgA3LJQ" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_FFxGUL6eEeWRz-VHgA3LJQ" annotatedElement="_XfLagb6GEeWRz-VHgA3LJQ">
-            <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fPK6I76IEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fPK6JL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_2g3pkL6JEeWRz-VHgA3LJQ" name="extension" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_YKfb0L6bEeWRz-VHgA3LJQ" annotatedElement="_fzRiML6HEeWRz-VHgA3LJQ">
-            <body>List of simple name-value extentions. Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_2g3pk76JEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2g3plL6JEeWRz-VHgA3LJQ" value="*"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_xImb0OK4EeSq5fATALSQkQ" name="Node">
@@ -112,11 +54,11 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cNt2UD_LEeWNAdBR30aJhw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cNvrgD_LEeWNAdBR30aJhw" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_W9zh097-EeW-BtRsuJPbqg" name="_stateSpec" type="_j2GU0N78EeW-BtRsuJPbqg" aggregation="composite" association="_W9zh0N7-EeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_tOFAk97rEeW-BtRsuJPbqg" name="_transferCapacitySpec" type="_KjZXM9yKEeWXdJnxZxtFYA" aggregation="composite" association="_tOFAkN7rEeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_7DdfM97vEeW-BtRsuJPbqg" name="_transferCostSpec" type="_KjZW8dyKEeWXdJnxZxtFYA" aggregation="composite" association="_7DdfMN7vEeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_lqLYA97wEeW-BtRsuJPbqg" name="_transferIntegritySpec" type="_KjZXGdyKEeWXdJnxZxtFYA" aggregation="composite" association="_lqLYAN7wEeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_kTBiY97xEeW-BtRsuJPbqg" name="_transferTimingSpec" type="_KjZXB9yKEeWXdJnxZxtFYA" aggregation="composite" association="_kTBiYN7xEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_W9zh097-EeW-BtRsuJPbqg" name="_state" type="_j2GU0N78EeW-BtRsuJPbqg" aggregation="composite" association="_W9zh0N7-EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_tOFAk97rEeW-BtRsuJPbqg" name="_transferCapacity" type="_KjZXM9yKEeWXdJnxZxtFYA" aggregation="composite" association="_tOFAkN7rEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_7DdfM97vEeW-BtRsuJPbqg" name="_transferCost" type="_KjZW8dyKEeWXdJnxZxtFYA" aggregation="composite" association="_7DdfMN7vEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lqLYA97wEeW-BtRsuJPbqg" name="_transferIntegrity" type="_KjZXGdyKEeWXdJnxZxtFYA" aggregation="composite" association="_lqLYAN7wEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_kTBiY97xEeW-BtRsuJPbqg" name="_transferTiming" type="_KjZXB9yKEeWXdJnxZxtFYA" aggregation="composite" association="_kTBiYN7xEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_xImb1OK4EeSq5fATALSQkQ" name="layerProtocolName" visibility="public" type="_i92HIL6PEeWRz-VHgA3LJQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xImb1eK4EeSq5fATALSQkQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xImb1uK4EeSq5fATALSQkQ" value="*"/>
@@ -135,14 +77,14 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_TiWCoD_AEeWNAdBR30aJhw" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_TiZtAD_AEeWNAdBR30aJhw" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_IZggA98AEeW-BtRsuJPbqg" name="_stateSpec" type="_j2GU0N78EeW-BtRsuJPbqg" aggregation="composite" association="_IZggAN8AEeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_WSiGU971EeW-BtRsuJPbqg" name="_transferCapacitySpec" type="_KjZXM9yKEeWXdJnxZxtFYA" aggregation="composite" association="_WSiGUN71EeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_cQkyE971EeW-BtRsuJPbqg" name="_transferCostSpec" type="_KjZW8dyKEeWXdJnxZxtFYA" aggregation="composite" association="_cQkyEN71EeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_gJx4Q971EeW-BtRsuJPbqg" name="_transferIntegritySpec" type="_KjZXGdyKEeWXdJnxZxtFYA" aggregation="composite" association="_gJx4QN71EeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_kZ4bg971EeW-BtRsuJPbqg" name="_transferTimingSpec" type="_KjZXB9yKEeWXdJnxZxtFYA" aggregation="composite" association="_kZ4bgN71EeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_rJUvA971EeW-BtRsuJPbqg" name="_riskParameterSpec" type="_KjZW99yKEeWXdJnxZxtFYA" aggregation="composite" association="_rJUvAN71EeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="__ET2w971EeW-BtRsuJPbqg" name="_validationSpec" type="_KjZXXNyKEeWXdJnxZxtFYA" aggregation="composite" association="__ET2wN71EeW-BtRsuJPbqg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_CM28E972EeW-BtRsuJPbqg" name="_lpTransitionSpec" type="_KjZW_dyKEeWXdJnxZxtFYA" aggregation="composite" association="_CM28EN72EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_IZggA98AEeW-BtRsuJPbqg" name="_state" type="_j2GU0N78EeW-BtRsuJPbqg" aggregation="composite" association="_IZggAN8AEeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WSiGU971EeW-BtRsuJPbqg" name="_transferCapacity" type="_KjZXM9yKEeWXdJnxZxtFYA" aggregation="composite" association="_WSiGUN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_cQkyE971EeW-BtRsuJPbqg" name="_transferCost" type="_KjZW8dyKEeWXdJnxZxtFYA" aggregation="composite" association="_cQkyEN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_gJx4Q971EeW-BtRsuJPbqg" name="_transferIntegrity" type="_KjZXGdyKEeWXdJnxZxtFYA" aggregation="composite" association="_gJx4QN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_kZ4bg971EeW-BtRsuJPbqg" name="_transferTiming" type="_KjZXB9yKEeWXdJnxZxtFYA" aggregation="composite" association="_kZ4bgN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_rJUvA971EeW-BtRsuJPbqg" name="_riskParameter" type="_KjZW99yKEeWXdJnxZxtFYA" aggregation="composite" association="_rJUvAN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="__ET2w971EeW-BtRsuJPbqg" name="_validation" type="_KjZXXNyKEeWXdJnxZxtFYA" aggregation="composite" association="__ET2wN71EeW-BtRsuJPbqg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_CM28E972EeW-BtRsuJPbqg" name="_lpTransition" type="_KjZW_dyKEeWXdJnxZxtFYA" aggregation="composite" association="_CM28EN72EeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_37fFROMCEeSdZOEXoN8VDQ" name="layerProtocolName" visibility="public" type="_i92HIL6PEeWRz-VHgA3LJQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_37fFReMCEeSdZOEXoN8VDQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_37fFRuMCEeSdZOEXoN8VDQ" value="*"/>
@@ -162,6 +104,7 @@ Is not present in more complex cases.</body>
           <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
 The structure of LTP supports all transport protocols including circuit and packet forms.</body>
         </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_3vF8gO_nEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_0rYyYtnXEeWIOYiRCk5bbQ" name="_layerProtocol" type="_r01pEL6nEeWRz-VHgA3LJQ" aggregation="composite" association="_0rPocNnXEeWIOYiRCk5bbQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_OlnfwNnYEeWIOYiRCk5bbQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_OlnfwdnYEeWIOYiRCk5bbQ" value="*"/>
@@ -170,46 +113,15 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_UMztkNnfEeWIOYiRCk5bbQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_UMztkdnfEeWIOYiRCk5bbQ" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Jkw_QL3wEeWxDaRqnNJFbQ" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_Jkw_Qb3wEeWxDaRqnNJFbQ" annotatedElement="_Jkw_QL3wEeWxDaRqnNJFbQ">
-            <body>UUID: An identifier that is universally unique&#xD;
-&#xD;
-(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Jkw_Qr3wEeWxDaRqnNJFbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Jkw_Q73wEeWxDaRqnNJFbQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_wnG-4L6fEeWRz-VHgA3LJQ" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_wnG-4b6fEeWRz-VHgA3LJQ" annotatedElement="_JhEg4L6GEeWRz-VHgA3LJQ">
-            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_wnG-4r6fEeWRz-VHgA3LJQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_wnG-476fEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_jbVYkL6IEeWRz-VHgA3LJQ" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_YeqqIL6dEeWRz-VHgA3LJQ" annotatedElement="_XfLagb6GEeWRz-VHgA3LJQ">
-            <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_jbVYk76IEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_jbVYlL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_9vLqYL6JEeWRz-VHgA3LJQ" name="extension" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_fAOkkL6bEeWRz-VHgA3LJQ" annotatedElement="_fzRiML6HEeWRz-VHgA3LJQ">
-            <body>List of simple name-value extentions. Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9vLqY76JEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9vLqZL6JEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_STzYA-_tEeWLlrwIF3w0vA" name="_state" type="_j2GU0N78EeW-BtRsuJPbqg" aggregation="composite" association="_STzYAO_tEeWLlrwIF3w0vA"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_093zYKU7EeWkWNPM1BHzGA" name="direction" type="_Ydx2sNnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_btsygNnnEeWIOYiRCk5bbQ" name="administrativeState" type="_zSpnYNnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ea0gENnnEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_hBBGQNnnEeWIOYiRCk5bbQ" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_It0sYEG-EeWMO5szP8dKiA" name="ServiceEndPoint">
         <ownedComment xmi:type="uml:Comment" xmi:id="_It0sYUG-EeWMO5szP8dKiA" annotatedElement="_It0sYEG-EeWMO5szP8dKiA">
           <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
 The structure of LTP supports all transport protocols including circuit and packet forms.</body>
         </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_6frNwO_nEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_aFAUM9nYEeWIOYiRCk5bbQ" name="_layerProtocol" type="_r01pEL6nEeWRz-VHgA3LJQ" aggregation="composite" association="_aFAUMNnYEeWIOYiRCk5bbQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_c7QIkNnYEeWIOYiRCk5bbQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_c7Z5kNnYEeWIOYiRCk5bbQ" value="*"/>
@@ -218,44 +130,15 @@ The structure of LTP supports all transport protocols including circuit and pack
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_euOhIEHBEeWqPKyD1j6LMg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_euQ9YEHBEeWqPKyD1j6LMg" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Ly2AYL3wEeWxDaRqnNJFbQ" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_Ly2AYb3wEeWxDaRqnNJFbQ" annotatedElement="_Ly2AYL3wEeWxDaRqnNJFbQ">
-            <body>UUID: An identifier that is universally unique&#xD;
-&#xD;
-(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Ly2AYr3wEeWxDaRqnNJFbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Ly2AY73wEeWxDaRqnNJFbQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_k2-3ML6IEeWRz-VHgA3LJQ" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_cJdg4L6dEeWRz-VHgA3LJQ" annotatedElement="_XfLagb6GEeWRz-VHgA3LJQ">
-            <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_k2-3M76IEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_k2-3NL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_57jdML6IEeWRz-VHgA3LJQ" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_wWBrYL6eEeWRz-VHgA3LJQ" annotatedElement="_JhEg4L6GEeWRz-VHgA3LJQ">
-            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_57jdM76IEeWRz-VHgA3LJQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_57jdNL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_AH_U0L6KEeWRz-VHgA3LJQ" name="extension" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_hJGVkL6bEeWRz-VHgA3LJQ" annotatedElement="_fzRiML6HEeWRz-VHgA3LJQ">
-            <body>List of simple name-value extentions. Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_AH_U076KEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_AH_U1L6KEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_S3giA-_tEeWLlrwIF3w0vA" name="_state" type="_oJg1UN79EeW-BtRsuJPbqg" aggregation="composite" association="_S3giAO_tEeWLlrwIF3w0vA"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_9hsOkKU7EeWkWNPM1BHzGA" name="direction" type="_Ydx2sNnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_AZLb8NnoEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_oC2ZEEG_EeWAMMFKXSVi-w" name="ConnectionEndPoint">
         <ownedComment xmi:type="uml:Comment" xmi:id="_oC2ZEUG_EeWAMMFKXSVi-w" annotatedElement="_oC2ZEEG_EeWAMMFKXSVi-w">
           <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
 The structure of LTP supports all transport protocols including circuit and packet forms.</body>
         </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_89GScO_nEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_hv9Ns9nYEeWIOYiRCk5bbQ" name="_layerProtocol" type="_r01pEL6nEeWRz-VHgA3LJQ" aggregation="composite" association="_hv9NsNnYEeWIOYiRCk5bbQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ldi5wNnYEeWIOYiRCk5bbQ" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ldi5wdnYEeWIOYiRCk5bbQ" value="*"/>
@@ -269,38 +152,8 @@ The structure of LTP supports all transport protocols including circuit and pack
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_WeZjgEHCEeWqPKyD1j6LMg" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_cfZ_c4bpEeWLkaOCu--9xg" name="_peerConnectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_cfZ_cIbpEeWLkaOCu--9xg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="__Xf6AL3vEeWxDaRqnNJFbQ" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="__Xf6Ab3vEeWxDaRqnNJFbQ" annotatedElement="__Xf6AL3vEeWxDaRqnNJFbQ">
-            <body>UUID: An identifier that is universally unique&#xD;
-&#xD;
-(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="__Xf6Ar3vEeWxDaRqnNJFbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="__Xf6A73vEeWxDaRqnNJFbQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_brCsEL6IEeWRz-VHgA3LJQ" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_RweT0L6dEeWRz-VHgA3LJQ" annotatedElement="_XfLagb6GEeWRz-VHgA3LJQ">
-            <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_brCsE76IEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_brCsFL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_pbztQL6IEeWRz-VHgA3LJQ" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_dhGMwL6eEeWRz-VHgA3LJQ" annotatedElement="_JhEg4L6GEeWRz-VHgA3LJQ">
-            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pbztQ76IEeWRz-VHgA3LJQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pbztRL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_0NbnUL6JEeWRz-VHgA3LJQ" name="extension" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_JL-1IL6bEeWRz-VHgA3LJQ" annotatedElement="_fzRiML6HEeWRz-VHgA3LJQ">
-            <body>List of simple name-value extentions. Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_0NbnU76JEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_0NbnVL6JEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TPT-A-_tEeWLlrwIF3w0vA" name="_state" type="_TlA2gN79EeW-BtRsuJPbqg" aggregation="composite" association="_TPT-AO_tEeWLlrwIF3w0vA"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_6a7R8KU7EeWkWNPM1BHzGA" name="direction" type="_Ydx2sNnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_tNzWwNnoEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_kuDzQEHaEeWqPKyD1j6LMg" name="ConnectivityService">
         <ownedComment xmi:type="uml:Comment" xmi:id="_kuDzQUHaEeWqPKyD1j6LMg" annotatedElement="_kuDzQEHaEeWqPKyD1j6LMg">
@@ -308,6 +161,7 @@ The structure of LTP supports all transport protocols including circuit and pack
 &#xD;
 At the lowest level of recursion, a FC represents a cross-connection within an NE.</body>
         </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_ntHGoO_nEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_4Es8M2kIEeWZEqTYAF8eqA" name="_servicePort" type="_MIWTIGh5EeWZEqTYAF8eqA" aggregation="composite" association="_4Es8MGkIEeWZEqTYAF8eqA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9mgX4GkIEeWZEqTYAF8eqA" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9mgX4WkIEeWZEqTYAF8eqA" value="*"/>
@@ -316,44 +170,14 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YteN0EUdEeWEwNCluy4jrw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YtgqEEUdEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_CDe_IL3wEeWxDaRqnNJFbQ" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_CDe_Ib3wEeWxDaRqnNJFbQ" annotatedElement="_CDe_IL3wEeWxDaRqnNJFbQ">
-            <body>UUID: An identifier that is universally unique&#xD;
-&#xD;
-(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CDe_Ir3wEeWxDaRqnNJFbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_CDe_I73wEeWxDaRqnNJFbQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_rX60oL6IEeWRz-VHgA3LJQ" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_jN4wcL6eEeWRz-VHgA3LJQ" annotatedElement="_JhEg4L6GEeWRz-VHgA3LJQ">
-            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rX60o76IEeWRz-VHgA3LJQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rX60pL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_dVVDoL6IEeWRz-VHgA3LJQ" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_DyrGwL6eEeWRz-VHgA3LJQ" annotatedElement="_XfLagb6GEeWRz-VHgA3LJQ">
-            <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_dVVDo76IEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_dVVDpL6IEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_1UjAYL6JEeWRz-VHgA3LJQ" name="extension" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_V-BkQL6bEeWRz-VHgA3LJQ" annotatedElement="_fzRiML6HEeWRz-VHgA3LJQ">
-            <body>List of simple name-value extentions. Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_1UjAY76JEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_1UjAZL6JEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_WFu44u_qEeWLlrwIF3w0vA" name="_connConstraints" type="_DOEi4O-IEeWLlrwIF3w0vA" aggregation="composite" association="_WFlH4O_qEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_oP678-_rEeWLlrwIF3w0vA" name="_connSchedule" type="_rBq8YO-fEeWLlrwIF3w0vA" aggregation="composite" association="_oP678O_rEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nfDxo-_pEeWLlrwIF3w0vA" name="_state" type="_j2GU0N78EeW-BtRsuJPbqg" aggregation="composite" association="_nfDxoO_pEeWLlrwIF3w0vA"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_kuDzQ0HaEeWqPKyD1j6LMg" name="layerProtocolName" visibility="public" type="_i92HIL6PEeWRz-VHgA3LJQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_kuDzREHaEeWqPKyD1j6LMg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_kuDzRUHaEeWqPKyD1j6LMg" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_caIFkNnlEeWIOYiRCk5bbQ" name="direction" type="_PvuhcNnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_bjUSANnoEeWIOYiRCk5bbQ" name="administrativeState" type="_zSpnYNnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_d4A4gNnoEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_gCAD0NnoEeWIOYiRCk5bbQ" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_IZ3vcEHbEeWqPKyD1j6LMg" name="Connection">
         <ownedComment xmi:type="uml:Comment" xmi:id="_IZ3vcUHbEeWqPKyD1j6LMg" annotatedElement="_IZ3vcEHbEeWqPKyD1j6LMg">
@@ -361,11 +185,12 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
 &#xD;
 At the lowest level of recursion, a FC represents a cross-connection within an NE.</body>
         </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_ttEd8O_nEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_nttnA2kFEeWZEqTYAF8eqA" name="_connectionPort" type="_sIutIGh-EeWZEqTYAF8eqA" aggregation="composite" association="_nttnAGkFEeWZEqTYAF8eqA">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_sA_aEGkFEeWZEqTYAF8eqA" value="2"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sA_aEWkFEeWZEqTYAF8eqA" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZiYSAEUcEeWEwNCluy4jrw" name="_path" type="_kkzTEEUbEeWKAbXi7_SowQ" aggregation="composite" association="_ZiXD4EUcEeWEwNCluy4jrw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZiYSAEUcEeWEwNCluy4jrw" name="_route" type="_kkzTEEUbEeWKAbXi7_SowQ" aggregation="composite" association="_ZiXD4EUcEeWEwNCluy4jrw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_obpMUEUcEeWEwNCluy4jrw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_obsPoEUcEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
@@ -373,43 +198,12 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Aoh_oN5TEeWHTPgMsm3CIw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Aokb4N5TEeWHTPgMsm3CIw" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_9Dda0L3vEeWxDaRqnNJFbQ" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_9Dda0b3vEeWxDaRqnNJFbQ" annotatedElement="_9Dda0L3vEeWxDaRqnNJFbQ">
-            <body>UUID: An identifier that is universally unique&#xD;
-&#xD;
-(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_9Dda0r3vEeWxDaRqnNJFbQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_9Dda073vEeWxDaRqnNJFbQ" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_JhEg4L6GEeWRz-VHgA3LJQ" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_JhEg4b6GEeWRz-VHgA3LJQ" annotatedElement="_JhEg4L6GEeWRz-VHgA3LJQ">
-            <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_JhEg4r6GEeWRz-VHgA3LJQ" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_JhEg476GEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_XfLagb6GEeWRz-VHgA3LJQ" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_XfLagr6GEeWRz-VHgA3LJQ" annotatedElement="_XfLagb6GEeWRz-VHgA3LJQ">
-            <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_XfLag76GEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_XfLahL6GEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_fzRiML6HEeWRz-VHgA3LJQ" name="extension" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_fzRiMb6HEeWRz-VHgA3LJQ" annotatedElement="_fzRiML6HEeWRz-VHgA3LJQ">
-            <body>List of simple name-value extentions. Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_fzRiMr6HEeWRz-VHgA3LJQ"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_fzRiM76HEeWRz-VHgA3LJQ" value="*"/>
-        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_B0rIk-_sEeWLlrwIF3w0vA" name="_state" type="_TlA2gN79EeW-BtRsuJPbqg" aggregation="composite" association="_B0rIkO_sEeWLlrwIF3w0vA"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_IZ3vc0HbEeWqPKyD1j6LMg" name="layerProtocolName" visibility="public" type="_i92HIL6PEeWRz-VHgA3LJQ">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_IZ3vdEHbEeWqPKyD1j6LMg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_IZ3vdUHbEeWqPKyD1j6LMg" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_V2I0INnlEeWIOYiRCk5bbQ" name="direction" type="_PvuhcNnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_lqMbYNnoEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_nq8yMNnoEeWIOYiRCk5bbQ" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_kkzTEEUbEeWKAbXi7_SowQ" name="Route">
         <ownedComment xmi:type="uml:Comment" xmi:id="_kkzTEUUbEeWKAbXi7_SowQ" annotatedElement="_kkzTEEUbEeWKAbXi7_SowQ">
@@ -547,7 +341,7 @@ Where the client – server relationship is fixed 1:1 and immutable, the layers 
           </ownedComment>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW8dyKEeWXdJnxZxtFYA" name="TransferCostPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW8dyKEeWXdJnxZxtFYA" name="TransferCostPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW8tyKEeWXdJnxZxtFYA" annotatedElement="_KjZW8dyKEeWXdJnxZxtFYA">
           <body>The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. &#xD;
 They may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity&#xD;
@@ -562,7 +356,7 @@ Using an entity will incur a cost. </body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZW9tyKEeWXdJnxZxtFYA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW99yKEeWXdJnxZxtFYA" name="RiskParameterPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW99yKEeWXdJnxZxtFYA" name="RiskParameterPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW-NyKEeWXdJnxZxtFYA" annotatedElement="_KjZW99yKEeWXdJnxZxtFYA">
           <body>The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. &#xD;
 The risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.&#xD;
@@ -585,7 +379,7 @@ Where two TopologicalEntities have a common risk characteristic they have an ele
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZW_NyKEeWXdJnxZxtFYA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW_dyKEeWXdJnxZxtFYA" name="LayerProtocolTransitionPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW_dyKEeWXdJnxZxtFYA" name="LayerProtocolTransitionPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW_tyKEeWXdJnxZxtFYA" annotatedElement="_KjZW_dyKEeWXdJnxZxtFYA">
           <body>Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. &#xD;
 This abstraction is relevant when considering multi-layer routing. &#xD;
@@ -609,7 +403,7 @@ Links that included details in this Pac are often referred to as Transitional Li
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXBtyKEeWXdJnxZxtFYA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXB9yKEeWXdJnxZxtFYA" name="TransferTimingPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXB9yKEeWXdJnxZxtFYA" name="TransferTimingPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXCNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXB9yKEeWXdJnxZxtFYA">
           <body>A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.</body>
         </ownedComment>
@@ -648,7 +442,7 @@ Applies to TDM systems (and not packet).</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXGNyKEeWXdJnxZxtFYA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXGdyKEeWXdJnxZxtFYA" name="TransferIntegrityPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXGdyKEeWXdJnxZxtFYA" name="TransferIntegrityPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXGtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXGdyKEeWXdJnxZxtFYA">
           <body>Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.&#xD;
 It includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.&#xD;
@@ -707,7 +501,7 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXMtyKEeWXdJnxZxtFYA" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXM9yKEeWXdJnxZxtFYA" name="TransferCapacityPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXM9yKEeWXdJnxZxtFYA" name="TransferCapacityPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXNNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXM9yKEeWXdJnxZxtFYA">
           <body>The TopologicalEntity derives capacity from the underlying realization. &#xD;
 A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.&#xD;
@@ -746,7 +540,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXRNyKEeWXdJnxZxtFYA" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXXNyKEeWXdJnxZxtFYA" name="ValidationPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXXNyKEeWXdJnxZxtFYA" name="ValidationPac">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXXdyKEeWXdJnxZxtFYA" annotatedElement="_KjZXXNyKEeWXdJnxZxtFYA">
           <body>Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.</body>
         </ownedComment>
@@ -780,25 +574,16 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
         <ownedComment xmi:type="uml:Comment" xmi:id="_aMQ88d5xEeWd9KDn6x5Skg" annotatedElement="_aMQ88N5xEeWd9KDn6x5Skg">
           <body>Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes</body>
         </ownedComment>
+        <generalization xmi:type="uml:Generalization" xmi:id="_WKDJcO_wEeWLlrwIF3w0vA" general="_xEvjkN8AEeW-BtRsuJPbqg"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_eMyr8t6ZEeWd9KDn6x5Skg" name="_telink" type="_BnjHcN5lEeWd9KDn6x5Skg" aggregation="composite" association="_eMpiAN6ZEeWd9KDn6x5Skg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_rNMnMN6ZEeWd9KDn6x5Skg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rNMnMd6ZEeWd9KDn6x5Skg" value="*"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_e4pzkN5xEeWd9KDn6x5Skg" name="uuid" visibility="public" type="_FRi-QNnWEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_e4pzkd5xEeWd9KDn6x5Skg" annotatedElement="_e4pzkN5xEeWd9KDn6x5Skg">
-            <body>UUID: An identifier that is universally unique&#xD;
-&#xD;
-(consider in the context of Identifier: A property of an entity/role with a value that is unique within an identifier space, where the identifier space is itself globally unique, and immutable. An identifier carries no semantics with respect to the purpose or state of the entity)</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_e4pzkt5xEeWd9KDn6x5Skg" value="1"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e4pzk95xEeWd9KDn6x5Skg" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KNiZ8N5yEeWd9KDn6x5Skg" name="routingConstraint">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Qn3ZEN5yEeWd9KDn6x5Skg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Qn3ZEd5yEeWd9KDn6x5Skg" value="1"/>
-        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_iuK74-_xEeWLlrwIF3w0vA" name="_routingConstraint" type="_DOEi4O-IEeWLlrwIF3w0vA" aggregation="composite" association="_iuK74O_xEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jyVHk-_xEeWLlrwIF3w0vA" name="_optimizationConstraint" type="_PK97QO-fEeWLlrwIF3w0vA" aggregation="composite" association="_jyVHkO_xEeWLlrwIF3w0vA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_jUIIo-_xEeWLlrwIF3w0vA" name="_objectiveFunction" type="_kJjOAO-fEeWLlrwIF3w0vA" aggregation="composite" association="_jUIIoO_xEeWLlrwIF3w0vA"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_xEvjkN8AEeW-BtRsuJPbqg" name="GlobalComponent" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_xEvjkN8AEeW-BtRsuJPbqg" name="GlobalClass" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjkd8AEeW-BtRsuJPbqg" annotatedElement="_xEvjkN8AEeW-BtRsuJPbqg">
           <body>The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. </body>
         </ownedComment>
@@ -812,28 +597,28 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjnt8AEeW-BtRsuJPbqg" value="1"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjn98AEeW-BtRsuJPbqg" name="name" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjoN8AEeW-BtRsuJPbqg" annotatedElement="_JhEg4L6GEeWRz-VHgA3LJQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjoN8AEeW-BtRsuJPbqg">
             <body>List of names. A property of an entity with a value that is unique in some namespace but may change during the life of the entity. A name carries no semantics with respect to the purpose of the entity.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjod8AEeW-BtRsuJPbqg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjot8AEeW-BtRsuJPbqg" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjo98AEeW-BtRsuJPbqg" name="label" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjpN8AEeW-BtRsuJPbqg" annotatedElement="_XfLagb6GEeWRz-VHgA3LJQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjpN8AEeW-BtRsuJPbqg">
             <body>List of labels.A property of an entity with a value that is not expected to be unique and is allowed to change. A label carries no semantics with respect to the purpose of the entity and has no effect on the entity behavior or state.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjpd8AEeW-BtRsuJPbqg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjpt8AEeW-BtRsuJPbqg" value="*"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_xEvjp98AEeW-BtRsuJPbqg" name="extension" visibility="public" type="_6efrYNnVEeWIOYiRCk5bbQ">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjqN8AEeW-BtRsuJPbqg" annotatedElement="_fzRiML6HEeWRz-VHgA3LJQ">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjqN8AEeW-BtRsuJPbqg">
             <body>List of simple name-value extentions. Extension provides an opportunity to define properties not declared in the class that extend the class enabling a realization with simple ad-hoc extension of standard classes to be conformant.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_xEvjqd8AEeW-BtRsuJPbqg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjqt8AEeW-BtRsuJPbqg" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_UhrZoN8qEeWT9tG0gGLRFw" name="LocalComponent" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_UhrZoN8qEeWT9tG0gGLRFw" name="LocalClass" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_UhrZod8qEeWT9tG0gGLRFw" annotatedElement="_UhrZoN8qEeWT9tG0gGLRFw">
           <body>The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. </body>
         </ownedComment>
@@ -841,7 +626,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_j2GU0N78EeW-BtRsuJPbqg" name="AdminStatePac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_j2GU0N78EeW-BtRsuJPbqg" name="AdminStatePac">
         <ownedComment xmi:type="uml:Comment" xmi:id="__hsSIN78EeW-BtRsuJPbqg">
           <annotatedElement xmi:type="uml:Class" href="CoreModel.uml#_RG6VILEtEeSZUdYfPSdgew"/>
           <body>Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.</body>
@@ -865,7 +650,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2g979EeW-BtRsuJPbqg" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2hN79EeW-BtRsuJPbqg" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_DOEi4O-IEeWLlrwIF3w0vA" name="ConnectivityConstraints">
+      <packagedElement xmi:type="uml:Class" xmi:id="_DOEi4O-IEeWLlrwIF3w0vA" name="ConnectivityConstraint">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_RhdgwL2HEeWdore3Cxez9g" name="costCharacteristic" visibility="public" type="_8ZRqwdv-EeWowYqZXEhn3A">
           <ownedComment xmi:type="uml:Comment" xmi:id="_Rhdgwb2HEeWdore3Cxez9g" annotatedElement="_RhdgwL2HEeWdore3Cxez9g">
             <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
@@ -910,7 +695,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_lY2XULvZEeWYrqoqXLgguw" name="serviceType" type="_0-X6sLvZEeWYrqoqXLgguw"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_PK97QO-fEeWLlrwIF3w0vA" name="PathOptimizationConstraints">
+      <packagedElement xmi:type="uml:Class" xmi:id="_PK97QO-fEeWLlrwIF3w0vA" name="PathOptimizationConstraint">
         <ownedAttribute xmi:type="uml:Property" xmi:id="_H7MS8N5pEeWd9KDn6x5Skg" name="trafficInterruption" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_kJjOAO-fEeWLlrwIF3w0vA" name="PathObjectiveFunction">
@@ -1360,6 +1145,14 @@ Z		&quot;Z&quot;					indicates UTC (rather than local time)&#xD;
 HH		&quot;00&quot;..&quot;23&quot;			time zone difference in hours&#xD;
 Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
         </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_l1ltgO-pEeWLlrwIF3w0vA" name="value" visibility="public">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_l1ltge-pEeWLlrwIF3w0vA" annotatedElement="_l1ltgO-pEeWLlrwIF3w0vA">
+            <body>The specific value of the universal id</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_l1ltgu-pEeWLlrwIF3w0vA" value="1"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_l1ltg--pEeWLlrwIF3w0vA" value="1"/>
+        </ownedAttribute>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_JarZQOKxEeSq5fATALSQkQ" name="Associations">
@@ -1439,13 +1232,13 @@ Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ZiXq8EUcEeWEwNCluy4jrw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ZiXq8UUcEeWEwNCluy4jrw" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_ZiZgIEUcEeWEwNCluy4jrw" name="_fc" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_ZiXD4EUcEeWEwNCluy4jrw"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_ZiZgIEUcEeWEwNCluy4jrw" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_ZiXD4EUcEeWEwNCluy4jrw"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="_p4w_sEUeEeWEwNCluy4jrw" name="RouteIsDescribedByLowerConnections" memberEnd="_p4y04EUeEeWEwNCluy4jrw _p40DAEUeEeWEwNCluy4jrw">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_p4yN0EUeEeWEwNCluy4jrw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_p4yN0UUeEeWEwNCluy4jrw" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_p4y04EUeEeWEwNCluy4jrw" name="_fcRoute" type="_kkzTEEUbEeWKAbXi7_SowQ" association="_p4w_sEUeEeWEwNCluy4jrw">
+        <ownedEnd xmi:type="uml:Property" xmi:id="_p4y04EUeEeWEwNCluy4jrw" name="_route" type="_kkzTEEUbEeWKAbXi7_SowQ" association="_p4w_sEUeEeWEwNCluy4jrw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_x40xEEUfEeWEwNCluy4jrw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_x430YEUfEeWEwNCluy4jrw" value="1"/>
         </ownedEnd>
@@ -1454,7 +1247,7 @@ Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_4ErWsUUcEeWEwNCluy4jrw" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_4Esk0EUcEeWEwNCluy4jrw" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_4EuaAEUcEeWEwNCluy4jrw" name="_containingFc" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_4ErWsEUcEeWEwNCluy4jrw">
+        <ownedEnd xmi:type="uml:Property" xmi:id="_4EuaAEUcEeWEwNCluy4jrw" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_4ErWsEUcEeWEwNCluy4jrw">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZQn-MEUdEeWEwNCluy4jrw"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ZQqacEUdEeWEwNCluy4jrw" value="1"/>
         </ownedEnd>
@@ -1715,83 +1508,143 @@ Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
       <packagedElement xmi:type="uml:Usage" xmi:id="_iQzbUN6WEeWd9KDn6x5Skg" name="ComputesPathBetweenServicePorts" client="_AivIMOKxEeSq5fATALSQkQ" supplier="_MIWTIGh5EeWZEqTYAF8eqA"/>
       <packagedElement xmi:type="uml:Usage" xmi:id="_jmVOYN6XEeWd9KDn6x5Skg" name="OptimizesPath" client="_5ASPgN6MEeWd9KDn6x5Skg" supplier="_aMQ88N5xEeWd9KDn6x5Skg"/>
       <packagedElement xmi:type="uml:Usage" xmi:id="_yPo2kN6WEeWd9KDn6x5Skg" name="PathCompOperatesOnContext" client="_5ASPgN6MEeWd9KDn6x5Skg" supplier="_sfccMOK0EeSq5fATALSQkQ"/>
-      <packagedElement xmi:type="uml:Association" xmi:id="_WSiGUN71EeW-BtRsuJPbqg" name="LinkHasCapacitySpec" memberEnd="_WSiGU971EeW-BtRsuJPbqg _WSiGVd71EeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_WSiGUN71EeW-BtRsuJPbqg" name="LinkHasCapacityPac" memberEnd="_WSiGU971EeW-BtRsuJPbqg _WSiGVd71EeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WSiGUd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_WSiGUt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_WSiGVd71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_WSiGUN71EeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_cQkyEN71EeW-BtRsuJPbqg" name="LinkHasCostSpec" memberEnd="_cQkyE971EeW-BtRsuJPbqg _cQujEN71EeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_cQkyEN71EeW-BtRsuJPbqg" name="LinkHasCostPac" memberEnd="_cQkyE971EeW-BtRsuJPbqg _cQujEN71EeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_cQkyEd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_cQkyEt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_cQujEN71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_cQkyEN71EeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_gJx4QN71EeW-BtRsuJPbqg" name="LinkHasIntegritySpec" memberEnd="_gJx4Q971EeW-BtRsuJPbqg _gJx4Rd71EeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_gJx4QN71EeW-BtRsuJPbqg" name="LinkHasIntegrityPac" memberEnd="_gJx4Q971EeW-BtRsuJPbqg _gJx4Rd71EeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_gJx4Qd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_gJx4Qt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_gJx4Rd71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_gJx4QN71EeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_rJUvAN71EeW-BtRsuJPbqg" name="LinkHasRiskSpec" memberEnd="_rJUvA971EeW-BtRsuJPbqg _rJUvBd71EeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_rJUvAN71EeW-BtRsuJPbqg" name="LinkHasRiskPac" memberEnd="_rJUvA971EeW-BtRsuJPbqg _rJUvBd71EeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_rJUvAd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_rJUvAt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_rJUvBd71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_rJUvAN71EeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_IZggAN8AEeW-BtRsuJPbqg" name="LinkHasStateSpec" memberEnd="_IZggA98AEeW-BtRsuJPbqg _IZpp8N8AEeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_IZggAN8AEeW-BtRsuJPbqg" name="LinkHasStatePac" memberEnd="_IZggA98AEeW-BtRsuJPbqg _IZpp8N8AEeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IZggAd8AEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IZggAt8AEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_IZpp8N8AEeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_IZggAN8AEeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_kZ4bgN71EeW-BtRsuJPbqg" name="LinkHasTimingSpec" memberEnd="_kZ4bg971EeW-BtRsuJPbqg _kZ4bhd71EeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_kZ4bgN71EeW-BtRsuJPbqg" name="LinkHasTimingPac" memberEnd="_kZ4bg971EeW-BtRsuJPbqg _kZ4bhd71EeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_kZ4bgd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_kZ4bgt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_kZ4bhd71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_kZ4bgN71EeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_CM28EN72EeW-BtRsuJPbqg" name="LinkHasTransitionSpec" memberEnd="_CM28E972EeW-BtRsuJPbqg _CM28Fd72EeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_CM28EN72EeW-BtRsuJPbqg" name="LinkHasTransitionPac" memberEnd="_CM28E972EeW-BtRsuJPbqg _CM28Fd72EeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_CM28Ed72EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CM28Et72EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_CM28Fd72EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_CM28EN72EeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="__ET2wN71EeW-BtRsuJPbqg" name="LinkHasValidationSpec" memberEnd="__ET2w971EeW-BtRsuJPbqg __EdnwN71EeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="__ET2wN71EeW-BtRsuJPbqg" name="LinkHasValidationPac" memberEnd="__ET2w971EeW-BtRsuJPbqg __EdnwN71EeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__ET2wd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__ET2wt71EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="__EdnwN71EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="__ET2wN71EeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_tOFAkN7rEeW-BtRsuJPbqg" name="NodeHasCapacitySpec" memberEnd="_tOFAk97rEeW-BtRsuJPbqg _tOFAld7rEeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_tOFAkN7rEeW-BtRsuJPbqg" name="NodeHasCapacityPac" memberEnd="_tOFAk97rEeW-BtRsuJPbqg _tOFAld7rEeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tOFAkd7rEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_tOFAkt7rEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_tOFAld7rEeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_tOFAkN7rEeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_7DdfMN7vEeW-BtRsuJPbqg" name="NodeHasCostSpec" memberEnd="_7DdfM97vEeW-BtRsuJPbqg _7DmpIN7vEeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_7DdfMN7vEeW-BtRsuJPbqg" name="NodeHasCostPac" memberEnd="_7DdfM97vEeW-BtRsuJPbqg _7DmpIN7vEeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_7DdfMd7vEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_7DdfMt7vEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_7DmpIN7vEeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_7DdfMN7vEeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_lqLYAN7wEeW-BtRsuJPbqg" name="NodeHasIntegritySpec" memberEnd="_lqLYA97wEeW-BtRsuJPbqg _lqLYBd7wEeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_lqLYAN7wEeW-BtRsuJPbqg" name="NodeHasIntegrityPac" memberEnd="_lqLYA97wEeW-BtRsuJPbqg _lqLYBd7wEeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_lqLYAd7wEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_lqLYAt7wEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_lqLYBd7wEeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_lqLYAN7wEeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_W9zh0N7-EeW-BtRsuJPbqg" name="NodeHasStateSpec" memberEnd="_W9zh097-EeW-BtRsuJPbqg _W9zh1d7-EeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_W9zh0N7-EeW-BtRsuJPbqg" name="NodeHasStatePac" memberEnd="_W9zh097-EeW-BtRsuJPbqg _W9zh1d7-EeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_W9zh0d7-EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_W9zh0t7-EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_W9zh1d7-EeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_W9zh0N7-EeW-BtRsuJPbqg"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Association" xmi:id="_kTBiYN7xEeW-BtRsuJPbqg" name="NodeHasTimingSpec" memberEnd="_kTBiY97xEeW-BtRsuJPbqg _kTBiZd7xEeW-BtRsuJPbqg">
+      <packagedElement xmi:type="uml:Association" xmi:id="_kTBiYN7xEeW-BtRsuJPbqg" name="NodeHasTimingPac" memberEnd="_kTBiY97xEeW-BtRsuJPbqg _kTBiZd7xEeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_kTBiYd7xEeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_kTBiYt7xEeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
         <ownedEnd xmi:type="uml:Property" xmi:id="_kTBiZd7xEeW-BtRsuJPbqg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_kTBiYN7xEeW-BtRsuJPbqg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_B0rIkO_sEeWLlrwIF3w0vA" name="ConnectionHasStatePac" memberEnd="_B0rIk-_sEeWLlrwIF3w0vA _B00SgO_sEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_B0rIke_sEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_B0rIku_sEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_B00SgO_sEeWLlrwIF3w0vA" name="_connection" type="_IZ3vcEHbEeWqPKyD1j6LMg" association="_B0rIkO_sEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_TPT-AO_tEeWLlrwIF3w0vA" name="ConnEPHasStatePac" memberEnd="_TPT-A-_tEeWLlrwIF3w0vA _TPT-Be_tEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_TPT-Ae_tEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_TPT-Au_tEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_TPT-Be_tEeWLlrwIF3w0vA" name="_connectionEndPoint" type="_oC2ZEEG_EeWAMMFKXSVi-w" association="_TPT-AO_tEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_WFlH4O_qEeWLlrwIF3w0vA" name="ConnServiceHasConnConstraints" memberEnd="_WFu44u_qEeWLlrwIF3w0vA _WFu45O_qEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WFu44O_qEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_WFu44e_qEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_WFu45O_qEeWLlrwIF3w0vA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_WFlH4O_qEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_oP678O_rEeWLlrwIF3w0vA" name="ConnServiceHasSchedule" memberEnd="_oP678-_rEeWLlrwIF3w0vA _oP679e_rEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oP678e_rEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oP678u_rEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_oP679e_rEeWLlrwIF3w0vA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_oP678O_rEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_nfDxoO_pEeWLlrwIF3w0vA" name="ConnServiceHasStatePac" memberEnd="_nfDxo-_pEeWLlrwIF3w0vA _nfDxpe_pEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_nfDxoe_pEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_nfDxou_pEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_nfDxpe_pEeWLlrwIF3w0vA" name="_service" type="_kuDzQEHaEeWqPKyD1j6LMg" association="_nfDxoO_pEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_STzYAO_tEeWLlrwIF3w0vA" name="NodeEPHasStatePac" memberEnd="_STzYA-_tEeWLlrwIF3w0vA _STzYBe_tEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_STzYAe_tEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_STzYAu_tEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_STzYBe_tEeWLlrwIF3w0vA" name="_nodeEdgePoint" type="_i1UzkD-3EeWNAdBR30aJhw" association="_STzYAO_tEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_S3giAO_tEeWLlrwIF3w0vA" name="ServiceEPHasStatePac" memberEnd="_S3giA-_tEeWLlrwIF3w0vA _S3giBe_tEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_S3giAe_tEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_S3giAu_tEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_S3giBe_tEeWLlrwIF3w0vA" name="_serviceEndPoiont" type="_It0sYEG-EeWMO5szP8dKiA" association="_S3giAO_tEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_iuK74O_xEeWLlrwIF3w0vA" name="PathHasConnConstraints" memberEnd="_iuK74-_xEeWLlrwIF3w0vA _iuK75e_xEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_iuK74e_xEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_iuK74u_xEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_iuK75e_xEeWLlrwIF3w0vA" name="_path" type="_aMQ88N5xEeWd9KDn6x5Skg" association="_iuK74O_xEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_jUIIoO_xEeWLlrwIF3w0vA" name="PathHasObjectiveFunction" memberEnd="_jUIIo-_xEeWLlrwIF3w0vA _jUIIpe_xEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_jUIIoe_xEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jUIIou_xEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_jUIIpe_xEeWLlrwIF3w0vA" name="_path" type="_aMQ88N5xEeWd9KDn6x5Skg" association="_jUIIoO_xEeWLlrwIF3w0vA"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Association" xmi:id="_jyVHkO_xEeWLlrwIF3w0vA" name="PathHasOptimizationConstraints" memberEnd="_jyVHk-_xEeWLlrwIF3w0vA _jyVHle_xEeWLlrwIF3w0vA">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_jyVHke_xEeWLlrwIF3w0vA" source="org.eclipse.papyrus">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_jyVHku_xEeWLlrwIF3w0vA" key="nature" value="UML_Nature"/>
+        </eAnnotations>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_jyVHle_xEeWLlrwIF3w0vA" name="_path" type="_aMQ88N5xEeWd9KDn6x5Skg" association="_jyVHkO_xEeWLlrwIF3w0vA"/>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_AivIMOKxEeSq5fATALSQkQ" name="Diagrams">
@@ -2153,34 +2006,6 @@ Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
   <OpenModel_Profile:OpenModelParameter xmi:id="_zEZcMb2YEeWdore3Cxez9g" base_Parameter="_zEZcML2YEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_L70owb2ZEeWdore3Cxez9g" base_Parameter="_L70owL2ZEeWdore3Cxez9g"/>
   <OpenModel_Profile:OpenModelParameter xmi:id="_Y9jZsb2ZEeWdore3Cxez9g" base_Parameter="_Y9jZsL2ZEeWdore3Cxez9g"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_9FGZkL3vEeWxDaRqnNJFbQ" base_StructuralFeature="_9Dda0L3vEeWxDaRqnNJFbQ" partOfObjectKey="1"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="__Xf6BL3vEeWxDaRqnNJFbQ" base_StructuralFeature="__Xf6AL3vEeWxDaRqnNJFbQ" partOfObjectKey="1"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_CDe_JL3wEeWxDaRqnNJFbQ" base_StructuralFeature="_CDe_IL3wEeWxDaRqnNJFbQ" partOfObjectKey="1"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Dke31L3wEeWxDaRqnNJFbQ" base_StructuralFeature="_Dke30L3wEeWxDaRqnNJFbQ" isInvariant="true" partOfObjectKey="1"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Jkw_RL3wEeWxDaRqnNJFbQ" base_StructuralFeature="_Jkw_QL3wEeWxDaRqnNJFbQ" partOfObjectKey="1"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_Ly2AZL3wEeWxDaRqnNJFbQ" base_StructuralFeature="_Ly2AYL3wEeWxDaRqnNJFbQ" partOfObjectKey="1"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_ONRbdL3wEeWxDaRqnNJFbQ" base_StructuralFeature="_ONRbcL3wEeWxDaRqnNJFbQ" partOfObjectKey="1"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_JhEg5L6GEeWRz-VHgA3LJQ" base_StructuralFeature="_JhEg4L6GEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_XfLahb6GEeWRz-VHgA3LJQ" base_StructuralFeature="_XfLagb6GEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_fzRiNL6HEeWRz-VHgA3LJQ" base_StructuralFeature="_fzRiML6HEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_btbRsL6IEeWRz-VHgA3LJQ" base_StructuralFeature="_brCsEL6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_dVVDpb6IEeWRz-VHgA3LJQ" base_StructuralFeature="_dVVDoL6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_fPK6Jb6IEeWRz-VHgA3LJQ" base_StructuralFeature="_fPK6IL6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_jbVYlb6IEeWRz-VHgA3LJQ" base_StructuralFeature="_jbVYkL6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_k2-3Nb6IEeWRz-VHgA3LJQ" base_StructuralFeature="_k2-3ML6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_mbbFdb6IEeWRz-VHgA3LJQ" base_StructuralFeature="_mbbFcL6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_pbztRb6IEeWRz-VHgA3LJQ" base_StructuralFeature="_pbztQL6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_rX60pb6IEeWRz-VHgA3LJQ" base_StructuralFeature="_rX60oL6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_s8ygtb6IEeWRz-VHgA3LJQ" base_StructuralFeature="_s8ygsL6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_57jdNb6IEeWRz-VHgA3LJQ" base_StructuralFeature="_57jdML6IEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_EtNB4L6JEeWRz-VHgA3LJQ" base_StructuralFeature="_EtDQ4L6JEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_0OxEEL6JEeWRz-VHgA3LJQ" base_StructuralFeature="_0NbnUL6JEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_1UjAZb6JEeWRz-VHgA3LJQ" base_StructuralFeature="_1UjAYL6JEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_2g3plb6JEeWRz-VHgA3LJQ" base_StructuralFeature="_2g3pkL6JEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_9vLqZb6JEeWRz-VHgA3LJQ" base_StructuralFeature="_9vLqYL6JEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_AH_U1b6KEeWRz-VHgA3LJQ" base_StructuralFeature="_AH_U0L6KEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_C5o9Fb6KEeWRz-VHgA3LJQ" base_StructuralFeature="_C5o9EL6KEeWRz-VHgA3LJQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_wovWkL6fEeWRz-VHgA3LJQ" base_StructuralFeature="_wnG-4L6fEeWRz-VHgA3LJQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_r01pJb6nEeWRz-VHgA3LJQ" base_Class="_r01pEL6nEeWRz-VHgA3LJQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_r01pJr6nEeWRz-VHgA3LJQ" base_StructuralFeature="_r01pE76nEeWRz-VHgA3LJQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_r01pJ76nEeWRz-VHgA3LJQ" base_StructuralFeature="_r01pF76nEeWRz-VHgA3LJQ"/>
@@ -2209,16 +2034,6 @@ Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
   <OpenModel_Profile:Experimental xmi:id="_2wnjENnjEeWIOYiRCk5bbQ" base_Element="_2wdyGNnjEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_V2I0IdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_V2I0INnlEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_caIFkdnlEeWIOYiRCk5bbQ" base_StructuralFeature="_caIFkNnlEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_btsygdnnEeWIOYiRCk5bbQ" base_StructuralFeature="_btsygNnnEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_ea0gEdnnEeWIOYiRCk5bbQ" base_StructuralFeature="_ea0gENnnEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_hBBGQdnnEeWIOYiRCk5bbQ" base_StructuralFeature="_hBBGQNnnEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_AZLb8dnoEeWIOYiRCk5bbQ" base_StructuralFeature="_AZLb8NnoEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_bjUSAdnoEeWIOYiRCk5bbQ" base_StructuralFeature="_bjUSANnoEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_d4A4gdnoEeWIOYiRCk5bbQ" base_StructuralFeature="_d4A4gNnoEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_gCAD0dnoEeWIOYiRCk5bbQ" base_StructuralFeature="_gCAD0NnoEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_lqNCcNnoEeWIOYiRCk5bbQ" base_StructuralFeature="_lqMbYNnoEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_nq8yMdnoEeWIOYiRCk5bbQ" base_StructuralFeature="_nq8yMNnoEeWIOYiRCk5bbQ"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_tNz90NnoEeWIOYiRCk5bbQ" base_StructuralFeature="_tNzWwNnoEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:Experimental xmi:id="_aepeENnqEeWIOYiRCk5bbQ" base_DataType="_adPI0NnqEeWIOYiRCk5bbQ" base_Element="_adPI0NnqEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:Experimental xmi:id="_aepeEdnqEeWIOYiRCk5bbQ" base_Element="_adPI0tnqEeWIOYiRCk5bbQ"/>
   <OpenModel_Profile:Experimental xmi:id="_aepeEtnqEeWIOYiRCk5bbQ" base_Element="_adPI1NnqEeWIOYiRCk5bbQ"/>
@@ -2274,8 +2089,6 @@ Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_PSJDod5vEeWd9KDn6x5Skg" base_StructuralFeature="_PSJDoN5vEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_YQ35Md5vEeWd9KDn6x5Skg" base_StructuralFeature="_YQ35MN5vEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_aMQ8-d5xEeWd9KDn6x5Skg" base_Class="_aMQ88N5xEeWd9KDn6x5Skg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_e4pzlN5xEeWd9KDn6x5Skg" base_StructuralFeature="_e4pzkN5xEeWd9KDn6x5Skg" partOfObjectKey="1"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_KNiZ8d5yEeWd9KDn6x5Skg" base_StructuralFeature="_KNiZ8N5yEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_9OvWUd5zEeWd9KDn6x5Skg" base_StructuralFeature="_9OvWUN5zEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_GU9nE96MEeWd9KDn6x5Skg" base_StructuralFeature="_GU9nEN6MEeWd9KDn6x5Skg"/>
   <OpenModel_Profile:OpenModelInterface xmi:id="_5ASPrN6MEeWd9KDn6x5Skg" base_Interface="_5ASPgN6MEeWd9KDn6x5Skg"/>
@@ -2365,4 +2178,35 @@ Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
   <OpenModel_Profile:OpenModelClass xmi:id="_PMwrAO-fEeWLlrwIF3w0vA" base_Class="_PK97QO-fEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_kJjOAu-fEeWLlrwIF3w0vA" base_Class="_kJjOAO-fEeWLlrwIF3w0vA"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_rBq8Yu-fEeWLlrwIF3w0vA" base_Class="_rBq8YO-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_l1lthO-pEeWLlrwIF3w0vA" base_StructuralFeature="_l1ltgO-pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nfDxpO_pEeWLlrwIF3w0vA" base_StructuralFeature="_nfDxo-_pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_nfDxpu_pEeWLlrwIF3w0vA" base_StructuralFeature="_nfDxpe_pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_GeF1oO_qEeWLlrwIF3w0vA" base_Association="_nfDxoO_pEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WFu44-_qEeWLlrwIF3w0vA" base_StructuralFeature="_WFu44u_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_WFu45e_qEeWLlrwIF3w0vA" base_StructuralFeature="_WFu45O_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_b1QngO_qEeWLlrwIF3w0vA" base_Association="_WFlH4O_qEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oP679O_rEeWLlrwIF3w0vA" base_StructuralFeature="_oP678-_rEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_oP679u_rEeWLlrwIF3w0vA" base_StructuralFeature="_oP679e_rEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_zr86YO_rEeWLlrwIF3w0vA" base_Association="_oP678O_rEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_B0rIlO_sEeWLlrwIF3w0vA" base_StructuralFeature="_B0rIk-_sEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_B00Sge_sEeWLlrwIF3w0vA" base_StructuralFeature="_B00SgO_sEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_HjcCMO_sEeWLlrwIF3w0vA" base_Association="_B0rIkO_sEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_STzYBO_tEeWLlrwIF3w0vA" base_StructuralFeature="_STzYA-_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_STzYBu_tEeWLlrwIF3w0vA" base_StructuralFeature="_STzYBe_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_S3giBO_tEeWLlrwIF3w0vA" base_StructuralFeature="_S3giA-_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_S3giBu_tEeWLlrwIF3w0vA" base_StructuralFeature="_S3giBe_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_TPT-BO_tEeWLlrwIF3w0vA" base_StructuralFeature="_TPT-A-_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_TPT-Bu_tEeWLlrwIF3w0vA" base_StructuralFeature="_TPT-Be_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_rtqjQO_tEeWLlrwIF3w0vA" base_Association="_STzYAO_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_smgPwO_tEeWLlrwIF3w0vA" base_Association="_S3giAO_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_tWlB0O_tEeWLlrwIF3w0vA" base_Association="_TPT-AO_tEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iuK75O_xEeWLlrwIF3w0vA" base_StructuralFeature="_iuK74-_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_iuK75u_xEeWLlrwIF3w0vA" base_StructuralFeature="_iuK75e_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jUIIpO_xEeWLlrwIF3w0vA" base_StructuralFeature="_jUIIo-_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jUIIpu_xEeWLlrwIF3w0vA" base_StructuralFeature="_jUIIpe_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jyVHlO_xEeWLlrwIF3w0vA" base_StructuralFeature="_jyVHk-_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_jyVHlu_xEeWLlrwIF3w0vA" base_StructuralFeature="_jyVHle_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_9zKzQO_xEeWLlrwIF3w0vA" base_Association="_iuK74O_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_-ybQ0O_xEeWLlrwIF3w0vA" base_Association="_jUIIoO_xEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:StrictComposite xmi:id="_ATIOkO_yEeWLlrwIF3w0vA" base_Association="_jyVHkO_xEeWLlrwIF3w0vA"/>
 </xmi:XMI>

--- a/TransportAPI/UML/TapiModule.uml
+++ b/TransportAPI/UML/TapiModule.uml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:OpenModel_Profile="http:///schemas/OpenModel_Profile/_0tU-YNyQEeW6C_FaABjU5w/14" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http:///schemas/OpenModel_Profile/_0tU-YNyQEeW6C_FaABjU5w/14 ../OpenModelProfile/OpenModel_Profile.profile.uml#_0tZP0NyQEeW6C_FaABjU5w">
-  <uml:Package xmi:id="_x9n08N36EeSMBfBYLVyuMA" name="TapiModule">
+  <uml:Package xmi:id="_x9n08N36EeSMBfBYLVyuMA" name="Tapi">
     <packagedElement xmi:type="uml:Package" xmi:id="_cpovMOK2EeSq5fATALSQkQ" name="Imports">
       <packageImport xmi:type="uml:PackageImport" xmi:id="_zrZAIIPDEeW-BdCalZQs7g">
         <importedPackage xmi:type="uml:Package" href="CoreModel.uml#_oGqilVLNEeO75dO39GbF8Q"/>
       </packageImport>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_DHnfwOKxEeSq5fATALSQkQ" name="ObjectClasses">
-      <packagedElement xmi:type="uml:Class" xmi:id="_ejyEgOKyEeSq5fATALSQkQ" name="Tapi::Topology">
+      <packagedElement xmi:type="uml:Class" xmi:id="_ejyEgOKyEeSq5fATALSQkQ" name="Topology">
         <ownedComment xmi:type="uml:Comment" xmi:id="_ejyEgeKyEeSq5fATALSQkQ" annotatedElement="_ejyEgOKyEeSq5fATALSQkQ">
           <body>The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. &#xD;
 At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). </body>
@@ -55,7 +55,7 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ejyEhuKyEeSq5fATALSQkQ" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_sfccMOK0EeSq5fATALSQkQ" name="Tapi::Context">
+      <packagedElement xmi:type="uml:Class" xmi:id="_sfccMOK0EeSq5fATALSQkQ" name="Context">
         <ownedComment xmi:type="uml:Comment" xmi:id="_sfccMeK0EeSq5fATALSQkQ">
           <body>The Network Control Domain (NCD) object class represents the scope of control that a particular SDN controller has with respect to a particular network, (i.e., encompassing a designated set of interconnected (virtual) network elements).</body>
         </ownedComment>
@@ -94,7 +94,7 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_2g3plL6JEeWRz-VHgA3LJQ" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_xImb0OK4EeSq5fATALSQkQ" name="Tapi::Node">
+      <packagedElement xmi:type="uml:Class" xmi:id="_xImb0OK4EeSq5fATALSQkQ" name="Node">
         <ownedComment xmi:type="uml:Comment" xmi:id="_xImb0eK4EeSq5fATALSQkQ" annotatedElement="_xImb0OK4EeSq5fATALSQkQ">
           <body>The ForwardingDomain (FD) object class models the “ForwardingDomain” topological component which is used to effect forwarding of transport characteristic information and offers the potential to enable forwarding. &#xD;
 At the lowest level of recursion, an FD (within a network element (NE)) represents a switch matrix (i.e., a fabric). Note that an NE can encompass multiple switch matrices (FDs). </body>
@@ -122,7 +122,7 @@ At the lowest level of recursion, an FD (within a network element (NE)) represen
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xImb1uK4EeSq5fATALSQkQ" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_37fFQOMCEeSdZOEXoN8VDQ" name="Tapi::Link" isLeaf="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_37fFQOMCEeSdZOEXoN8VDQ" name="Link">
         <ownedComment xmi:type="uml:Comment" xmi:id="_37fFQeMCEeSdZOEXoN8VDQ">
           <body>The Link object class models effective adjacency between two or more ForwardingDomains (FD). </body>
         </ownedComment>
@@ -157,7 +157,7 @@ Is not present in more complex cases.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_QpQJI4NtEeW35P6IpRw6Dg" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_i1UzkD-3EeWNAdBR30aJhw" name="Tapi::NodeEdgePoint" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_i1UzkD-3EeWNAdBR30aJhw" name="NodeEdgePoint">
         <ownedComment xmi:type="uml:Comment" xmi:id="_i1UzkT-3EeWNAdBR30aJhw" annotatedElement="_i1UzkD-3EeWNAdBR30aJhw">
           <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
 The structure of LTP supports all transport protocols including circuit and packet forms.</body>
@@ -205,7 +205,7 @@ The structure of LTP supports all transport protocols including circuit and pack
         <ownedAttribute xmi:type="uml:Property" xmi:id="_ea0gENnnEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_hBBGQNnnEeWIOYiRCk5bbQ" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_It0sYEG-EeWMO5szP8dKiA" name="Tapi::ServiceEndPoint">
+      <packagedElement xmi:type="uml:Class" xmi:id="_It0sYEG-EeWMO5szP8dKiA" name="ServiceEndPoint">
         <ownedComment xmi:type="uml:Comment" xmi:id="_It0sYUG-EeWMO5szP8dKiA" annotatedElement="_It0sYEG-EeWMO5szP8dKiA">
           <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
 The structure of LTP supports all transport protocols including circuit and packet forms.</body>
@@ -251,7 +251,7 @@ The structure of LTP supports all transport protocols including circuit and pack
         <ownedAttribute xmi:type="uml:Property" xmi:id="_9hsOkKU7EeWkWNPM1BHzGA" name="direction" type="_Ydx2sNnjEeWIOYiRCk5bbQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_AZLb8NnoEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_oC2ZEEG_EeWAMMFKXSVi-w" name="Tapi::ConnectionEndPoint">
+      <packagedElement xmi:type="uml:Class" xmi:id="_oC2ZEEG_EeWAMMFKXSVi-w" name="ConnectionEndPoint">
         <ownedComment xmi:type="uml:Comment" xmi:id="_oC2ZEUG_EeWAMMFKXSVi-w" annotatedElement="_oC2ZEEG_EeWAMMFKXSVi-w">
           <body>The LogicalTerminationPoint (LTP) object class encapsulates the termination and adaptation functions of one or more transport layers. &#xD;
 The structure of LTP supports all transport protocols including circuit and packet forms.</body>
@@ -302,7 +302,7 @@ The structure of LTP supports all transport protocols including circuit and pack
         <ownedAttribute xmi:type="uml:Property" xmi:id="_6a7R8KU7EeWkWNPM1BHzGA" name="direction" type="_Ydx2sNnjEeWIOYiRCk5bbQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_tNzWwNnoEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_kuDzQEHaEeWqPKyD1j6LMg" name="Tapi::ConnectivityService" isLeaf="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_kuDzQEHaEeWqPKyD1j6LMg" name="ConnectivityService">
         <ownedComment xmi:type="uml:Comment" xmi:id="_kuDzQUHaEeWqPKyD1j6LMg" annotatedElement="_kuDzQEHaEeWqPKyD1j6LMg">
           <body>The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.&#xD;
 &#xD;
@@ -355,7 +355,7 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
         <ownedAttribute xmi:type="uml:Property" xmi:id="_d4A4gNnoEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_gCAD0NnoEeWIOYiRCk5bbQ" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_IZ3vcEHbEeWqPKyD1j6LMg" name="Tapi::Connection">
+      <packagedElement xmi:type="uml:Class" xmi:id="_IZ3vcEHbEeWqPKyD1j6LMg" name="Connection">
         <ownedComment xmi:type="uml:Comment" xmi:id="_IZ3vcUHbEeWqPKyD1j6LMg" annotatedElement="_IZ3vcEHbEeWqPKyD1j6LMg">
           <body>The ForwardingConstruct (FC) object class models enabled potential for forwarding between two or more LTPs and like the LTP supports any transport protocol including all circuit and packet forms.&#xD;
 &#xD;
@@ -411,7 +411,7 @@ At the lowest level of recursion, a FC represents a cross-connection within an N
         <ownedAttribute xmi:type="uml:Property" xmi:id="_lqMbYNnoEeWIOYiRCk5bbQ" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_nq8yMNnoEeWIOYiRCk5bbQ" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_kkzTEEUbEeWKAbXi7_SowQ" name="Tapi::Route">
+      <packagedElement xmi:type="uml:Class" xmi:id="_kkzTEEUbEeWKAbXi7_SowQ" name="Route">
         <ownedComment xmi:type="uml:Comment" xmi:id="_kkzTEUUbEeWKAbXi7_SowQ" annotatedElement="_kkzTEEUbEeWKAbXi7_SowQ">
           <body>The FC Route (FcRoute) object class models the individual routes of an FC. &#xD;
 The route of an FC object is represented by a list of FCs at a lower level. &#xD;
@@ -423,7 +423,7 @@ Note that depending on the service supported by an FC, an the FC can have multip
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_tAd7AEUfEeWEwNCluy4jrw" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_7vdU8Gh_EeWZEqTYAF8eqA" name="Tapi::LinkPort">
+      <packagedElement xmi:type="uml:Class" xmi:id="_7vdU8Gh_EeWZEqTYAF8eqA" name="LinkPort">
         <ownedComment xmi:type="uml:Comment" xmi:id="_7vdU8Wh_EeWZEqTYAF8eqA" annotatedElement="_7vdU8Gh_EeWZEqTYAF8eqA">
           <body>The association of the Link to LTPs is made via LinkEnd.&#xD;
 The LinkEnd object class models the access to the Link function. &#xD;
@@ -451,7 +451,7 @@ The Link can be considered as a component and the LinkEnd as a Port on that comp
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_7vdVBmh_EeWZEqTYAF8eqA" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_MIWTIGh5EeWZEqTYAF8eqA" name="Tapi::ServicePort">
+      <packagedElement xmi:type="uml:Class" xmi:id="_MIWTIGh5EeWZEqTYAF8eqA" name="ServicePort">
         <ownedComment xmi:type="uml:Comment" xmi:id="_MIWTIWh5EeWZEqTYAF8eqA" annotatedElement="_MIWTIGh5EeWZEqTYAF8eqA">
           <body>The association of the FC to LTPs is made via EndPoints.&#xD;
 The EndPoint (EP) object class models the access to the FC function. &#xD;
@@ -482,7 +482,7 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GU9nEt6MEeWd9KDn6x5Skg" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_sIutIGh-EeWZEqTYAF8eqA" name="Tapi::ConnectionPort">
+      <packagedElement xmi:type="uml:Class" xmi:id="_sIutIGh-EeWZEqTYAF8eqA" name="ConnectionPort">
         <ownedComment xmi:type="uml:Comment" xmi:id="_sIutIWh-EeWZEqTYAF8eqA" annotatedElement="_sIutIGh-EeWZEqTYAF8eqA">
           <body>The association of the FC to LTPs is made via EndPoints.&#xD;
 The EndPoint (EP) object class models the access to the FC function. &#xD;
@@ -509,7 +509,7 @@ The ForwadingConstruct can be considered as a component and the EndPoint as a Po
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_sIutLmh-EeWZEqTYAF8eqA" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_r01pEL6nEeWRz-VHgA3LJQ" name="Tapi::LayerProtocol">
+      <packagedElement xmi:type="uml:Class" xmi:id="_r01pEL6nEeWRz-VHgA3LJQ" name="LayerProtocol">
         <ownedComment xmi:type="uml:Comment" xmi:id="_r01pEb6nEeWRz-VHgA3LJQ" annotatedElement="_r01pEL6nEeWRz-VHgA3LJQ">
           <body>Each transport layer is represented by a LayerProtocol (LP) instance. The LayerProtocol instances it can be used for controlling termination and monitoring functionality. &#xD;
 It can also be used for controlling the adaptation (i.e. encapsulation and/or multiplexing of client signal), tandem connection monitoring, traffic conditioning and/or shaping functionality at an intermediate point along a connection. &#xD;
@@ -547,7 +547,7 @@ Where the client – server relationship is fixed 1:1 and immutable, the layers 
           </ownedComment>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW8dyKEeWXdJnxZxtFYA" name="Tapi::TransferCostPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW8dyKEeWXdJnxZxtFYA" name="TransferCostPac" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW8tyKEeWXdJnxZxtFYA" annotatedElement="_KjZW8dyKEeWXdJnxZxtFYA">
           <body>The cost characteristics of a TopologicalEntity not necessarily correlated to the cost of the underlying physical realization. &#xD;
 They may be quite specific to the individual TopologicalEntity e.g. opportunity cost. Relates to layer capacity&#xD;
@@ -562,7 +562,7 @@ Using an entity will incur a cost. </body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZW9tyKEeWXdJnxZxtFYA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW99yKEeWXdJnxZxtFYA" name="Tapi::RiskParameterPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW99yKEeWXdJnxZxtFYA" name="RiskParameterPac" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW-NyKEeWXdJnxZxtFYA" annotatedElement="_KjZW99yKEeWXdJnxZxtFYA">
           <body>The risk characteristics of a TopologicalEntity come directly from the underlying physical realization. &#xD;
 The risk characteristics propagate from the physical realization to the client and from the server layer to the client layer, this propagation may be modified by protection.&#xD;
@@ -585,7 +585,7 @@ Where two TopologicalEntities have a common risk characteristic they have an ele
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZW_NyKEeWXdJnxZxtFYA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW_dyKEeWXdJnxZxtFYA" name="Tapi::LayerProtocolTransitionPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZW_dyKEeWXdJnxZxtFYA" name="LayerProtocolTransitionPac" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZW_tyKEeWXdJnxZxtFYA" annotatedElement="_KjZW_dyKEeWXdJnxZxtFYA">
           <body>Relevant for a Link that is formed by abstracting one or more LTPs (in a stack) to focus on the flow and deemphasize the protocol transformation. &#xD;
 This abstraction is relevant when considering multi-layer routing. &#xD;
@@ -609,7 +609,7 @@ Links that included details in this Pac are often referred to as Transitional Li
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXBtyKEeWXdJnxZxtFYA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXB9yKEeWXdJnxZxtFYA" name="Tapi::TransferTimingPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXB9yKEeWXdJnxZxtFYA" name="TransferTimingPac" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXCNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXB9yKEeWXdJnxZxtFYA">
           <body>A TopologicalEntity will suffer effects from the underlying physical realization related to the timing of the information passed by the TopologicalEntity.</body>
         </ownedComment>
@@ -648,7 +648,7 @@ Applies to TDM systems (and not packet).</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXGNyKEeWXdJnxZxtFYA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXGdyKEeWXdJnxZxtFYA" name="Tapi::TransferIntegrityPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXGdyKEeWXdJnxZxtFYA" name="TransferIntegrityPac" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXGtyKEeWXdJnxZxtFYA" annotatedElement="_KjZXGdyKEeWXdJnxZxtFYA">
           <body>Transfer intergrity characteristic covers expected/specified/acceptable characteristic of degradation of the transfered signal.&#xD;
 It includes all aspects of possible degradation of signal content as well as any damage of any form to the total TopologicalEntity and to the carried signals.&#xD;
@@ -707,7 +707,7 @@ Does not apply to TDM as the TDM protocols maintain strict order.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXMtyKEeWXdJnxZxtFYA" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXM9yKEeWXdJnxZxtFYA" name="Tapi::TransferCapacityPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXM9yKEeWXdJnxZxtFYA" name="TransferCapacityPac" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXNNyKEeWXdJnxZxtFYA" annotatedElement="_KjZXM9yKEeWXdJnxZxtFYA">
           <body>The TopologicalEntity derives capacity from the underlying realization. &#xD;
 A TopologicalEntity may be an abstraction and virtualization of a subset of the underlying capability offered in a view or may be directly reflecting the underlying realization.&#xD;
@@ -746,7 +746,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXRNyKEeWXdJnxZxtFYA" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXXNyKEeWXdJnxZxtFYA" name="Tapi::ValidationPac" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_KjZXXNyKEeWXdJnxZxtFYA" name="ValidationPac" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_KjZXXdyKEeWXdJnxZxtFYA" annotatedElement="_KjZXXNyKEeWXdJnxZxtFYA">
           <body>Validation covers the various adjacenct discovery and reachability verification protocols. Also may cover Information source and degree of integrity.</body>
         </ownedComment>
@@ -758,7 +758,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_KjZXYdyKEeWXdJnxZxtFYA" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_BnjHcN5lEeWd9KDn6x5Skg" name="Tapi::TeLink" isLeaf="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_BnjHcN5lEeWd9KDn6x5Skg" name="TeLink">
         <ownedComment xmi:type="uml:Comment" xmi:id="_BnjHcd5lEeWd9KDn6x5Skg">
           <body>The Link object class models effective adjacency between two or more ForwardingDomains (FD). </body>
         </ownedComment>
@@ -776,7 +776,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_YGZVcd6ZEeWd9KDn6x5Skg" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_aMQ88N5xEeWd9KDn6x5Skg" name="Tapi::Path">
+      <packagedElement xmi:type="uml:Class" xmi:id="_aMQ88N5xEeWd9KDn6x5Skg" name="Path">
         <ownedComment xmi:type="uml:Comment" xmi:id="_aMQ88d5xEeWd9KDn6x5Skg" annotatedElement="_aMQ88N5xEeWd9KDn6x5Skg">
           <body>Path is described by an ordered list of TE Links. A TE Link is defined by a pair of Node/NodeEdgePoint IDs. A Connection is realized by concatenating link resources (associated with a Link) and the lower-level connections (cross-connections) in the different nodes</body>
         </ownedComment>
@@ -793,105 +793,12 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_e4pzkt5xEeWd9KDn6x5Skg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_e4pzk95xEeWd9KDn6x5Skg" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_KNiZ8N5yEeWd9KDn6x5Skg" name="routingConstraint" type="_ntqE4L2BEeWdore3Cxez9g">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_KNiZ8N5yEeWd9KDn6x5Skg" name="routingConstraint">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Qn3ZEN5yEeWd9KDn6x5Skg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Qn3ZEd5yEeWd9KDn6x5Skg" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Package" xmi:id="_gaXNwN78EeW-BtRsuJPbqg" name="StatePac">
-        <packagedElement xmi:type="uml:Class" xmi:id="_j2GU0N78EeW-BtRsuJPbqg" name="Tapi::AdminStatePac" isAbstract="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="__hsSIN78EeW-BtRsuJPbqg">
-            <annotatedElement xmi:type="uml:Class" href="CoreModel.uml#_RG6VILEtEeSZUdYfPSdgew"/>
-            <body>Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.</body>
-          </ownedComment>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_4ZaA0N78EeW-BtRsuJPbqg" name="administrativeState" type="_zSpnYNnjEeWIOYiRCk5bbQ"/>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_BY3PIN79EeW-BtRsuJPbqg" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_ER7uAN79EeW-BtRsuJPbqg" name="lifecycleState" visibility="public" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
-        </packagedElement>
-        <packagedElement xmi:type="uml:Class" xmi:id="_TlA2gN79EeW-BtRsuJPbqg" name="Tapi::OperationalStatePac" isAbstract="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_TlA2gd79EeW-BtRsuJPbqg">
-            <annotatedElement xmi:type="uml:Class" href="CoreModel.uml#_RG6VILEtEeSZUdYfPSdgew"/>
-            <body>Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.</body>
-          </ownedComment>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2g979EeW-BtRsuJPbqg" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2hN79EeW-BtRsuJPbqg" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
-        </packagedElement>
-        <packagedElement xmi:type="uml:Class" xmi:id="_oJg1UN79EeW-BtRsuJPbqg" name="Tapi::LifecycleStatePac" isAbstract="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_oJg1Ud79EeW-BtRsuJPbqg">
-            <annotatedElement xmi:type="uml:Class" href="CoreModel.uml#_RG6VILEtEeSZUdYfPSdgew"/>
-            <body>Provides state attributes for an entity that has lifeccycle aspects only.</body>
-          </ownedComment>
-          <ownedAttribute xmi:type="uml:Property" xmi:id="_oJg1U979EeW-BtRsuJPbqg" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
-        </packagedElement>
-      </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_ntqE4L2BEeWdore3Cxez9g" name="Tapi::ConnectivityConstraint">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_lY2XULvZEeWYrqoqXLgguw" name="serviceType" type="_0-X6sLvZEeWYrqoqXLgguw"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_-YtW8L11EeWdore3Cxez9g" name="requestedCapacity" type="_rNbewL1-EeWdore3Cxez9g"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_3bhE4L2BEeWdore3Cxez9g" name="serviceLevel">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_8GC6UL2BEeWdore3Cxez9g" annotatedElement="_ntqE4L2BEeWdore3Cxez9g">
-            <body>An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability</body>
-          </ownedComment>
-          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cE7T8L2REeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cE7T8b2REeWdore3Cxez9g" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_3_SWwL11EeWdore3Cxez9g" name="serviceLayer" type="_i92HIL6PEeWRz-VHgA3LJQ">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p_hKEL2SEeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_p_q7EL2SEeWdore3Cxez9g" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_RhdgwL2HEeWdore3Cxez9g" name="costCharacteristic" visibility="public" type="_8ZRqwdv-EeWowYqZXEhn3A">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_Rhdgwb2HEeWdore3Cxez9g" annotatedElement="_RhdgwL2HEeWdore3Cxez9g">
-            <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Rhdgwr2HEeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Rhdgw72HEeWdore3Cxez9g" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_x9cD4L2HEeWdore3Cxez9g" name="riskCharacteristic" visibility="public" type="_8ZRqz9v-EeWowYqZXEhn3A">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_x9cD4b2HEeWdore3Cxez9g" annotatedElement="_x9cD4L2HEeWdore3Cxez9g">
-            <body>A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_x9cD4r2HEeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_x9cD472HEeWdore3Cxez9g" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_GqeeML2JEeWdore3Cxez9g" name="latencyCharacteristic" visibility="public" type="_8ZRq-dv-EeWowYqZXEhn3A">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_GqeeMb2JEeWdore3Cxez9g" annotatedElement="_GqeeML2JEeWdore3Cxez9g">
-            <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
-          </ownedComment>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GqeeMr2JEeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GqeeM72JEeWdore3Cxez9g" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_1NmDMN6bEeWd9KDn6x5Skg" name="includePath" type="_aMQ88N5xEeWd9KDn6x5Skg">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_75LKYN6bEeWd9KDn6x5Skg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_75LKYd6bEeWd9KDn6x5Skg" value="*"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_4GhYIN6bEeWd9KDn6x5Skg" name="excludePath" type="_aMQ88N5xEeWd9KDn6x5Skg">
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_98_cQN6bEeWd9KDn6x5Skg"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_98_cQd6bEeWd9KDn6x5Skg" value="*"/>
-        </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_cM_LIL2OEeWdore3Cxez9g" name="Tapi::ScheduleInfo">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_nkyJ0L2OEeWdore3Cxez9g" name="startTime">
-          <type xmi:type="uml:DataType" href="CoreModel.uml#_oGqi1lLNEeO75dO39GbF8Q"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_651S8L2OEeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_65_D8L2OEeWdore3Cxez9g" value="1"/>
-        </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_qDhdIL2OEeWdore3Cxez9g" name="endTime">
-          <type xmi:type="uml:DataType" href="CoreModel.uml#_oGqi1lLNEeO75dO39GbF8Q"/>
-          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8s_SoL2OEeWdore3Cxez9g"/>
-          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8s_Sob2OEeWdore3Cxez9g" value="1"/>
-        </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_gzqTQN5nEeWd9KDn6x5Skg" name="Tapi::PathOptimizationConstraint">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_H7MS8N5pEeWd9KDn6x5Skg" name="trafficInterruption" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_hiAqMN5rEeWd9KDn6x5Skg" name="Tapi::PathObjectiveFunction">
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_9OvWUN5zEeWd9KDn6x5Skg" name="concurrentPaths" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_PSJDoN5vEeWd9KDn6x5Skg" name="bandwidthOptimization" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_OHiZEN5sEeWd9KDn6x5Skg" name="costOptimization" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_YQ35MN5vEeWd9KDn6x5Skg" name="linkUtilization" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_BS_lAN5rEeWd9KDn6x5Skg" name="resourceSharing" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_xEvjkN8AEeW-BtRsuJPbqg" name="Tapi::GlobalComponent" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_xEvjkN8AEeW-BtRsuJPbqg" name="GlobalComponent" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_xEvjkd8AEeW-BtRsuJPbqg" annotatedElement="_xEvjkN8AEeW-BtRsuJPbqg">
           <body>The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. </body>
         </ownedComment>
@@ -926,7 +833,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_xEvjqt8AEeW-BtRsuJPbqg" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Class" xmi:id="_UhrZoN8qEeWT9tG0gGLRFw" name="Tapi::LocalComponent" isAbstract="true">
+      <packagedElement xmi:type="uml:Class" xmi:id="_UhrZoN8qEeWT9tG0gGLRFw" name="LocalComponent" isAbstract="true">
         <ownedComment xmi:type="uml:Comment" xmi:id="_UhrZod8qEeWT9tG0gGLRFw" annotatedElement="_UhrZoN8qEeWT9tG0gGLRFw">
           <body>The TAPI GlobalComponent serves as the super class for all TAPI entities that can be directly retrieved by their ID. As such, these are first class entities and their ID is expected to be globally unique. </body>
         </ownedComment>
@@ -934,14 +841,103 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
           <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
         </ownedAttribute>
       </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_j2GU0N78EeW-BtRsuJPbqg" name="AdminStatePac" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="__hsSIN78EeW-BtRsuJPbqg">
+          <annotatedElement xmi:type="uml:Class" href="CoreModel.uml#_RG6VILEtEeSZUdYfPSdgew"/>
+          <body>Provides state attributes that are applicable to an entity that can be administered. Such an entity also has operational and lifecycle aspects.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4ZaA0N78EeW-BtRsuJPbqg" name="administrativeState" type="_zSpnYNnjEeWIOYiRCk5bbQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BY3PIN79EeW-BtRsuJPbqg" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ER7uAN79EeW-BtRsuJPbqg" name="lifecycleState" visibility="public" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_oJg1UN79EeW-BtRsuJPbqg" name="LifecycleStatePac" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_oJg1Ud79EeW-BtRsuJPbqg">
+          <annotatedElement xmi:type="uml:Class" href="CoreModel.uml#_RG6VILEtEeSZUdYfPSdgew"/>
+          <body>Provides state attributes for an entity that has lifeccycle aspects only.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_oJg1U979EeW-BtRsuJPbqg" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_TlA2gN79EeW-BtRsuJPbqg" name="OperationalStatePac" isAbstract="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_TlA2gd79EeW-BtRsuJPbqg">
+          <annotatedElement xmi:type="uml:Class" href="CoreModel.uml#_RG6VILEtEeSZUdYfPSdgew"/>
+          <body>Provides state attributes that are applicable to an entity that reflects operational aspects. Such an entity is expected to also have lifecycle aspects.</body>
+        </ownedComment>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2g979EeW-BtRsuJPbqg" name="operationalState" type="_uINi0NnjEeWIOYiRCk5bbQ"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_TlA2hN79EeW-BtRsuJPbqg" name="lifecycleState" type="_2wdyENnjEeWIOYiRCk5bbQ"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_DOEi4O-IEeWLlrwIF3w0vA" name="ConnectivityConstraints">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_RhdgwL2HEeWdore3Cxez9g" name="costCharacteristic" visibility="public" type="_8ZRqwdv-EeWowYqZXEhn3A">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Rhdgwb2HEeWdore3Cxez9g" annotatedElement="_RhdgwL2HEeWdore3Cxez9g">
+            <body>The list of costs where each cost relates to some aspect of the TopologicalEntity.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_Rhdgwr2HEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Rhdgw72HEeWdore3Cxez9g" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_4GhYIN6bEeWd9KDn6x5Skg" name="excludePath" type="_aMQ88N5xEeWd9KDn6x5Skg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_98_cQN6bEeWd9KDn6x5Skg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_98_cQd6bEeWd9KDn6x5Skg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_1NmDMN6bEeWd9KDn6x5Skg" name="includePath" type="_aMQ88N5xEeWd9KDn6x5Skg">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_75LKYN6bEeWd9KDn6x5Skg"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_75LKYd6bEeWd9KDn6x5Skg" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_GqeeML2JEeWdore3Cxez9g" name="latencyCharacteristic" visibility="public" type="_8ZRq-dv-EeWowYqZXEhn3A">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_GqeeMb2JEeWdore3Cxez9g" annotatedElement="_GqeeML2JEeWdore3Cxez9g">
+            <body>The effect on the latency of a queuing process. This only has significant effect for packet based systems and has a complex characteristic.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_GqeeMr2JEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_GqeeM72JEeWdore3Cxez9g" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_-YtW8L11EeWdore3Cxez9g" name="requestedCapacity" type="_rNbewL1-EeWdore3Cxez9g"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_x9cD4L2HEeWdore3Cxez9g" name="riskCharacteristic" visibility="public" type="_8ZRqz9v-EeWowYqZXEhn3A">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_x9cD4b2HEeWdore3Cxez9g" annotatedElement="_x9cD4L2HEeWdore3Cxez9g">
+            <body>A list of risk characteristics for consideration in an analysis of shared risk. Each element of the list represents a specific risk consideration.</body>
+          </ownedComment>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_x9cD4r2HEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_x9cD472HEeWdore3Cxez9g" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3_SWwL11EeWdore3Cxez9g" name="serviceLayer" type="_i92HIL6PEeWRz-VHgA3LJQ">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_p_hKEL2SEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_p_q7EL2SEeWdore3Cxez9g" value="*"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_3bhE4L2BEeWdore3Cxez9g" name="serviceLevel">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_8GC6UL2BEeWdore3Cxez9g">
+            <body>An abstract value the meaning of which is mutually agreed – typically represents metrics such as - Class of service, priority, resiliency, availability</body>
+          </ownedComment>
+          <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_cE7T8L2REeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_cE7T8b2REeWdore3Cxez9g" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_lY2XULvZEeWYrqoqXLgguw" name="serviceType" type="_0-X6sLvZEeWYrqoqXLgguw"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_PK97QO-fEeWLlrwIF3w0vA" name="PathOptimizationConstraints">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_H7MS8N5pEeWd9KDn6x5Skg" name="trafficInterruption" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_kJjOAO-fEeWLlrwIF3w0vA" name="PathObjectiveFunction">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PSJDoN5vEeWd9KDn6x5Skg" name="bandwidthOptimization" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_9OvWUN5zEeWd9KDn6x5Skg" name="concurrentPaths" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_OHiZEN5sEeWd9KDn6x5Skg" name="costOptimization" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_YQ35MN5vEeWd9KDn6x5Skg" name="linkUtilization" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_BS_lAN5rEeWd9KDn6x5Skg" name="resourceSharing" type="_pGsZEN5qEeWd9KDn6x5Skg"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Class" xmi:id="_rBq8YO-fEeWLlrwIF3w0vA" name="ScheduleInfo">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_qDhdIL2OEeWdore3Cxez9g" name="endTime" type="_6iCS8O-fEeWLlrwIF3w0vA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_8s_SoL2OEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8s_Sob2OEeWdore3Cxez9g" value="1"/>
+        </ownedAttribute>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_nkyJ0L2OEeWdore3Cxez9g" name="startTime" type="_6iCS8O-fEeWLlrwIF3w0vA">
+          <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_651S8L2OEeWdore3Cxez9g"/>
+          <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_65_D8L2OEeWdore3Cxez9g" value="1"/>
+        </ownedAttribute>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_F_8XwOKxEeSq5fATALSQkQ" name="TypeDefinitions">
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_0-X6sLvZEeWYrqoqXLgguw" name="Tapi::ServiceType">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_0-X6sLvZEeWYrqoqXLgguw" name="ServiceType">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_1OME8L1xEeWdore3Cxez9g" name="POINT_TO_POINT_CONNECTIVITY"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_4mNJoL1xEeWdore3Cxez9g" name="POINT_TO_MULTIPOINT_CONNECTIVTY"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8UPhoL1xEeWdore3Cxez9g" name="MULTIPOINT_CONNECTIVITY"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_smkSYL1yEeWdore3Cxez9g" name="Tapi::FixedCapacityValue">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_smkSYL1yEeWdore3Cxez9g" name="FixedCapacityValue">
         <ownedComment xmi:type="uml:Comment" xmi:id="_UEqsALvUEeWYrqoqXLgguw">
           <body>The Capacity (Bandwidth) values that are applicable for digital layers. </body>
         </ownedComment>
@@ -956,7 +952,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_oRItwL1zEeWdore3Cxez9g" name="200GBPS"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_mXlyML1zEeWdore3Cxez9g" name="400GBPS"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_EILagL6PEeWRz-VHgA3LJQ" name="Tapi::PortRole">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_EILagL6PEeWRz-VHgA3LJQ" name="PortRole">
         <ownedComment xmi:type="uml:Comment" xmi:id="_i47c0WkaEeWZEqTYAF8eqA">
           <body>The role of an end in the context of the function of the forwarding entity that it bounds</body>
         </ownedComment>
@@ -964,7 +960,7 @@ A TopologicalEntity may reflect one or more client protocols and one or more mem
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Q6aW4L6PEeWRz-VHgA3LJQ" name="ROOT"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Sia2gL6PEeWRz-VHgA3LJQ" name="LEAF"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_i92HIL6PEeWRz-VHgA3LJQ" name="Tapi::LayerProtocolName">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_i92HIL6PEeWRz-VHgA3LJQ" name="LayerProtocolName">
         <ownedComment xmi:type="uml:Comment" xmi:id="_mjS1wWkaEeWZEqTYAF8eqA">
           <body>Provides a controlled list of layer protocol names and indicates the naming authority.&#xD;
 &#xD;
@@ -980,7 +976,7 @@ Layer protocol names include:&#xD;
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_q7QpoL6PEeWRz-VHgA3LJQ" name="ETH"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_se8C4L6PEeWRz-VHgA3LJQ" name="MPLS_TP"/>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_6efrYNnVEeWIOYiRCk5bbQ" name="Tapi::NameAndValue">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_6efrYNnVEeWIOYiRCk5bbQ" name="NameAndValue">
         <ownedComment xmi:type="uml:Comment" xmi:id="_6efrYdnVEeWIOYiRCk5bbQ" annotatedElement="_6efrYNnVEeWIOYiRCk5bbQ">
           <body>A scoped name-value pair</body>
         </ownedComment>
@@ -1009,7 +1005,7 @@ Layer protocol names include:&#xD;
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_6efrbdnVEeWIOYiRCk5bbQ" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_FRi-QNnWEeWIOYiRCk5bbQ" name="Tapi::UniversalId">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_FRi-QNnWEeWIOYiRCk5bbQ" name="UniversalId">
         <ownedComment xmi:type="uml:Comment" xmi:id="_FRi-QdnWEeWIOYiRCk5bbQ" annotatedElement="_FRi-QNnWEeWIOYiRCk5bbQ">
           <body>The univeral ID value where the mechanism for generation is defned by some authority not directly referenced in the structure.</body>
         </ownedComment>
@@ -1022,7 +1018,7 @@ Layer protocol names include:&#xD;
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_FRi-RdnWEeWIOYiRCk5bbQ" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_PvuhcNnjEeWIOYiRCk5bbQ" name="Tapi::ForwardingDirection">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_PvuhcNnjEeWIOYiRCk5bbQ" name="ForwardingDirection">
         <ownedComment xmi:type="uml:Comment" xmi:id="_PvuhcdnjEeWIOYiRCk5bbQ" annotatedElement="_PvuhcNnjEeWIOYiRCk5bbQ">
           <body>The directionality of a Forwarding entity.</body>
         </ownedComment>
@@ -1042,7 +1038,7 @@ Layer protocol names include:&#xD;
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_Ydx2sNnjEeWIOYiRCk5bbQ" name="Tapi::TerminationDirection">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_Ydx2sNnjEeWIOYiRCk5bbQ" name="TerminationDirection">
         <ownedComment xmi:type="uml:Comment" xmi:id="_Ydx2sdnjEeWIOYiRCk5bbQ" annotatedElement="_Ydx2sNnjEeWIOYiRCk5bbQ">
           <body>The directionality of a termination entity</body>
         </ownedComment>
@@ -1079,7 +1075,7 @@ A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_dLDeINnjEeWIOYiRCk5bbQ" name="Tapi::PortDirection">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_dLDeINnjEeWIOYiRCk5bbQ" name="PortDirection">
         <ownedComment xmi:type="uml:Comment" xmi:id="_dLDeIdnjEeWIOYiRCk5bbQ" annotatedElement="_dLDeINnjEeWIOYiRCk5bbQ">
           <body>The orientation of flow at the Port of a Forwarding entity</body>
         </ownedComment>
@@ -1104,7 +1100,7 @@ A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_uINi0NnjEeWIOYiRCk5bbQ" name="Tapi::OperationalState">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_uINi0NnjEeWIOYiRCk5bbQ" name="OperationalState">
         <ownedComment xmi:type="uml:Comment" xmi:id="_uINi0dnjEeWIOYiRCk5bbQ" annotatedElement="_uINi0NnjEeWIOYiRCk5bbQ">
           <body>The possible values of the operationalState.</body>
         </ownedComment>
@@ -1119,7 +1115,7 @@ A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_zSpnYNnjEeWIOYiRCk5bbQ" name="Tapi::AdministrativeState">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_zSpnYNnjEeWIOYiRCk5bbQ" name="AdministrativeState">
         <ownedComment xmi:type="uml:Comment" xmi:id="_zSpnYdnjEeWIOYiRCk5bbQ" annotatedElement="_zSpnYNnjEeWIOYiRCk5bbQ">
           <body>The possible values of the administrativeState.</body>
         </ownedComment>
@@ -1134,7 +1130,7 @@ A SOURCE termiation can be bound to an INPUT Port of a Forwarding entity</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_2wdyENnjEeWIOYiRCk5bbQ" name="Tapi::LifecycleState">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_2wdyENnjEeWIOYiRCk5bbQ" name="LifecycleState">
         <ownedComment xmi:type="uml:Comment" xmi:id="_2wdyEdnjEeWIOYiRCk5bbQ" annotatedElement="_2wdyENnjEeWIOYiRCk5bbQ">
           <body>The possible values of the lifecycleState.</body>
         </ownedComment>
@@ -1161,7 +1157,7 @@ o	If the potential resource has been consumed (e.g. allocated to another client)
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_adPI0NnqEeWIOYiRCk5bbQ" name="Tapi::TerminationState">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_adPI0NnqEeWIOYiRCk5bbQ" name="TerminationState">
         <ownedComment xmi:type="uml:Comment" xmi:id="_adPI0dnqEeWIOYiRCk5bbQ" annotatedElement="_adPI0NnqEeWIOYiRCk5bbQ">
           <body>Provides support for the range of behaviours and specific states that an LP can take with respect to termination of the signal.&#xD;
 Indicates to what degree the LayerTermination is terminated.</body>
@@ -1202,7 +1198,7 @@ Indicates to what degree the LayerTermination is terminated.</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_rNbewL1-EeWdore3Cxez9g" name="Tapi::Capacity">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_rNbewL1-EeWdore3Cxez9g" name="Capacity">
         <ownedComment xmi:type="uml:Comment" xmi:id="_rNbewb1-EeWdore3Cxez9g" annotatedElement="_rNbewL1-EeWdore3Cxez9g">
           <body>Information on capacity of a particular TopologicalEntity.</body>
         </ownedComment>
@@ -1239,7 +1235,7 @@ Indicates to what degree the LayerTermination is terminated.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_rNbe0b1-EeWdore3Cxez9g" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRqwdv-EeWowYqZXEhn3A" name="Tapi::CostCharacteristic">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRqwdv-EeWowYqZXEhn3A" name="CostCharacteristic">
         <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRqwtv-EeWowYqZXEhn3A" annotatedElement="_8ZRqwdv-EeWowYqZXEhn3A">
           <body>The information for a particular cost characteristic.</body>
         </ownedComment>
@@ -1268,7 +1264,7 @@ Indicates to what degree the LayerTermination is terminated.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRqztv-EeWowYqZXEhn3A" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRq-dv-EeWowYqZXEhn3A" name="Tapi::QueuingLatency">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRq-dv-EeWowYqZXEhn3A" name="QueuingLatency">
         <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq-tv-EeWowYqZXEhn3A" annotatedElement="_8ZRq-dv-EeWowYqZXEhn3A">
           <body>Provides information on latency characteristic for a particular stated trafficProperty.</body>
         </ownedComment>
@@ -1289,7 +1285,7 @@ Indicates to what degree the LayerTermination is terminated.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRrAtv-EeWowYqZXEhn3A" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRqz9v-EeWowYqZXEhn3A" name="Tapi::RiskCharacteristic">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRqz9v-EeWowYqZXEhn3A" name="RiskCharacteristic">
         <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq0Nv-EeWowYqZXEhn3A" annotatedElement="_8ZRqz9v-EeWowYqZXEhn3A">
           <body>The information for a particular risk characteristic where there is a list of risk identifiers related to that characteristic.</body>
         </ownedComment>
@@ -1312,7 +1308,7 @@ Depending upon the importance of the traffic being routed different risk charact
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRq2Nv-EeWowYqZXEhn3A" value="*"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRq69v-EeWowYqZXEhn3A" name="Tapi::ValidationMechanism">
+      <packagedElement xmi:type="uml:DataType" xmi:id="_8ZRq69v-EeWowYqZXEhn3A" name="ValidationMechanism">
         <ownedComment xmi:type="uml:Comment" xmi:id="_8ZRq7Nv-EeWowYqZXEhn3A" annotatedElement="_8ZRq69v-EeWowYqZXEhn3A">
           <body>Identifies the validation mechanism and describes the characteristics of that mechanism</body>
         </ownedComment>
@@ -1341,12 +1337,29 @@ Depending upon the importance of the traffic being routed different risk charact
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_8ZRq-Nv-EeWowYqZXEhn3A" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_pGsZEN5qEeWd9KDn6x5Skg" name="Tapi::DirectiveValue">
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_pGsZEN5qEeWd9KDn6x5Skg" name="DirectiveValue">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_u2nJQN5qEeWd9KDn6x5Skg" name="MINIMIZE"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_v7ftsN5qEeWd9KDn6x5Skg" name="MAXIMIZE"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ULsT4N5sEeWd9KDn6x5Skg" name="ALLOW"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_VvXtIN5sEeWd9KDn6x5Skg" name="DISALLOW"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_4rVysN5qEeWd9KDn6x5Skg" name="DONT_CARE"/>
+      </packagedElement>
+      <packagedElement xmi:type="uml:DataType" xmi:id="_6iCS8O-fEeWLlrwIF3w0vA" name="DateAndTime">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_6iCS8e-fEeWLlrwIF3w0vA" annotatedElement="_6iCS8O-fEeWLlrwIF3w0vA">
+          <body>This primitive type defines the date and time according to the following structure:&#xD;
+&quot;yyyyMMddhhmmss.s[Z|{+|-}HHMm]&quot; where:&#xD;
+yyyy	&quot;0000&quot;..&quot;9999&quot;	year&#xD;
+MM		&quot;01&quot;..&quot;12&quot;			month&#xD;
+dd		&quot;01&quot;..&quot;31&quot;			day&#xD;
+hh		&quot;00&quot;..&quot;23&quot;			hour&#xD;
+mm		&quot;00&quot;..&quot;59&quot;			minute&#xD;
+ss		&quot;00&quot;..&quot;59&quot;			second&#xD;
+s		&quot;.0&quot;..&quot;.9&quot;			tenth of second (set to &quot;.0&quot; if EMS or NE cannot support this granularity)&#xD;
+Z		&quot;Z&quot;					indicates UTC (rather than local time)&#xD;
+{+|-}	&quot;+&quot; or &quot;-&quot;			delta from UTC&#xD;
+HH		&quot;00&quot;..&quot;23&quot;			time zone difference in hours&#xD;
+Mm		&quot;00&quot;..&quot;59&quot;			time zone difference in minutes.</body>
+        </ownedComment>
       </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_JarZQOKxEeSq5fATALSQkQ" name="Associations">
@@ -1627,7 +1640,7 @@ Depending upon the importance of the traffic being routed different risk charact
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IzuHYaf4EeW6jfwWQNiYcg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IzuHYqf4EeW6jfwWQNiYcg" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_Iz6UoKf4EeW6jfwWQNiYcg" name="tapi::node" type="_xImb0OK4EeSq5fATALSQkQ" association="_IzuHYKf4EeW6jfwWQNiYcg">
+        <ownedEnd xmi:type="uml:Property" xmi:id="_Iz6UoKf4EeW6jfwWQNiYcg" name="_node" type="_xImb0OK4EeSq5fATALSQkQ" association="_IzuHYKf4EeW6jfwWQNiYcg">
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_N1sMcKf4EeW6jfwWQNiYcg" value="1"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_N1sMcaf4EeW6jfwWQNiYcg" value="1"/>
         </ownedEnd>
@@ -1742,7 +1755,7 @@ Depending upon the importance of the traffic being routed different risk charact
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_CM28Ed72EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_CM28Et72EeW-BtRsuJPbqg" key="nature" value="UML_Nature"/>
         </eAnnotations>
-        <ownedEnd xmi:type="uml:Property" xmi:id="_CM28Fd72EeW-BtRsuJPbqg" name="tapi::link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_CM28EN72EeW-BtRsuJPbqg"/>
+        <ownedEnd xmi:type="uml:Property" xmi:id="_CM28Fd72EeW-BtRsuJPbqg" name="_link" type="_37fFQOMCEeSdZOEXoN8VDQ" association="_CM28EN72EeW-BtRsuJPbqg"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Association" xmi:id="__ET2wN71EeW-BtRsuJPbqg" name="LinkHasValidationSpec" memberEnd="__ET2w971EeW-BtRsuJPbqg __EdnwN71EeW-BtRsuJPbqg">
         <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__ET2wd71EeW-BtRsuJPbqg" source="org.eclipse.papyrus">
@@ -1790,7 +1803,7 @@ Depending upon the importance of the traffic being routed different risk charact
       </ownedComment>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_6dmmUEtFEeW7b92SEnwDVg" name="Interfaces">
-      <packagedElement xmi:type="uml:Interface" xmi:id="_-ht5oPMtEeSb-q8_djA2ng" name="Tapi::TopologyService">
+      <packagedElement xmi:type="uml:Interface" xmi:id="_-ht5oPMtEeSb-q8_djA2ng" name="TopologyService">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_taDjMPMvEeSb-q8_djA2ng" name="getTopologyDetails">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_0HRXMPMxEeSb-q8_djA2ng" name="topologyIdOrName" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
@@ -1829,7 +1842,7 @@ Depending upon the importance of the traffic being routed different risk charact
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_AgHtklJFEeWDQNzGZgIgfQ" name="link" type="_37fFQOMCEeSdZOEXoN8VDQ" direction="out" effect="read"/>
         </ownedOperation>
       </packagedElement>
-      <packagedElement xmi:type="uml:Interface" xmi:id="_WHPN4FJvEeWcs7ZjyujtOg" name="Tapi::ConnectivityService">
+      <packagedElement xmi:type="uml:Interface" xmi:id="_WHPN4FJvEeWcs7ZjyujtOg" name="ConnectivityService">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_WHPN5VJvEeWcs7ZjyujtOg" name="getConnectionDetails">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_7BwFULvMEeWYrqoqXLgguw" name="serviceIdOrName" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
@@ -1880,16 +1893,16 @@ Depending upon the importance of the traffic being routed different risk charact
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hoAc0KU5EeWkWNPM1BHzGA" value="2"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hoJmwKU5EeWkWNPM1BHzGA" value="*"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SK70ML2KEeWdore3Cxez9g" name="connConstraint" type="_ntqE4L2BEeWdore3Cxez9g" isUnique="false" effect="read"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_xuBqsL2OEeWdore3Cxez9g" name="connSchedule" type="_cM_LIL2OEeWdore3Cxez9g" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_SK70ML2KEeWdore3Cxez9g" name="connConstraint" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_xuBqsL2OEeWdore3Cxez9g" name="connSchedule" isUnique="false" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_zEZcML2YEeWdore3Cxez9g" name="connService" type="_kuDzQEHaEeWqPKyD1j6LMg" isUnique="false" direction="out"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_qH8fkL2NEeWdore3Cxez9g" name="updateConnectivityService">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_JqtJcL2TEeWdore3Cxez9g" name="serviceIdOrName" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_YRJ1cL2TEeWdore3Cxez9g" name="connConstraint" type="_ntqE4L2BEeWdore3Cxez9g" isUnique="false" effect="read"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_qzgEYL2VEeWdore3Cxez9g" name="connSchedule" type="_cM_LIL2OEeWdore3Cxez9g" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_YRJ1cL2TEeWdore3Cxez9g" name="connConstraint" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_qzgEYL2VEeWdore3Cxez9g" name="connSchedule" isUnique="false" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_L70owL2ZEeWdore3Cxez9g" name="connService" type="_kuDzQEHaEeWqPKyD1j6LMg" isUnique="false" direction="out" effect="update"/>
         </ownedOperation>
         <ownedOperation xmi:type="uml:Operation" xmi:id="_lQR28L2WEeWdore3Cxez9g" name="deleteConnectivityService">
@@ -1899,14 +1912,14 @@ Depending upon the importance of the traffic being routed different risk charact
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_Y9jZsL2ZEeWdore3Cxez9g" name="connService" type="_kuDzQEHaEeWqPKyD1j6LMg" isUnique="false" direction="out" effect="delete"/>
         </ownedOperation>
       </packagedElement>
-      <packagedElement xmi:type="uml:Interface" xmi:id="_5ASPgN6MEeWd9KDn6x5Skg" name="Tapi::PathComputationService">
+      <packagedElement xmi:type="uml:Interface" xmi:id="_5ASPgN6MEeWd9KDn6x5Skg" name="PathComputationService">
         <ownedOperation xmi:type="uml:Operation" xmi:id="_5ASPmt6MEeWd9KDn6x5Skg" name="computeP2PPath">
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPnN6MEeWd9KDn6x5Skg" name="servicePort" type="_MIWTIGh5EeWZEqTYAF8eqA" isUnique="false" effect="read">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_5ASPnd6MEeWd9KDn6x5Skg" value="2"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_5ASPnt6MEeWd9KDn6x5Skg" value="2"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPn96MEeWd9KDn6x5Skg" name="routingConstraint" type="_ntqE4L2BEeWdore3Cxez9g" isUnique="false" effect="read"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_8XQOgN6QEeWd9KDn6x5Skg" name="objectiveFunction" type="_hiAqMN5rEeWd9KDn6x5Skg" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPn96MEeWd9KDn6x5Skg" name="routingConstraint" isUnique="false" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_8XQOgN6QEeWd9KDn6x5Skg" name="objectiveFunction" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPod6MEeWd9KDn6x5Skg" name="path" type="_aMQ88N5xEeWd9KDn6x5Skg" direction="out">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_SdGWMN6PEeWd9KDn6x5Skg" value="1"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_SdGWMd6PEeWd9KDn6x5Skg" value="*"/>
@@ -1916,9 +1929,9 @@ Depending upon the importance of the traffic being routed different risk charact
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPqt6MEeWd9KDn6x5Skg" name="pathIdOrName" effect="read">
             <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
           </ownedParameter>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_pPFOUN6REeWd9KDn6x5Skg" name="routingConstraint" type="_ntqE4L2BEeWdore3Cxez9g" effect="read"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_tj9j4N6REeWd9KDn6x5Skg" name="optimizationConstraint" type="_gzqTQN5nEeWd9KDn6x5Skg" effect="read"/>
-          <ownedParameter xmi:type="uml:Parameter" xmi:id="_wQie4N6REeWd9KDn6x5Skg" name="objectiveFunction" type="_hiAqMN5rEeWd9KDn6x5Skg" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_pPFOUN6REeWd9KDn6x5Skg" name="routingConstraint" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_tj9j4N6REeWd9KDn6x5Skg" name="optimizationConstraint" effect="read"/>
+          <ownedParameter xmi:type="uml:Parameter" xmi:id="_wQie4N6REeWd9KDn6x5Skg" name="objectiveFunction" effect="read"/>
           <ownedParameter xmi:type="uml:Parameter" xmi:id="_5ASPq96MEeWd9KDn6x5Skg" name="path" type="_aMQ88N5xEeWd9KDn6x5Skg" isUnique="false" direction="out" effect="update">
             <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_hNr1oN6PEeWd9KDn6x5Skg" value="1"/>
             <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_hN0_kN6PEeWd9KDn6x5Skg" value="*"/>
@@ -2348,4 +2361,8 @@ Depending upon the importance of the traffic being routed different risk charact
   <OpenModel_Profile:OpenModelAttribute xmi:id="_xGhsR98AEeW-BtRsuJPbqg" base_StructuralFeature="_xEvjp98AEeW-BtRsuJPbqg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_UhrZst8qEeWT9tG0gGLRFw" base_Class="_UhrZoN8qEeWT9tG0gGLRFw"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_dlarAd8qEeWT9tG0gGLRFw" base_StructuralFeature="_dlarAN8qEeWT9tG0gGLRFw" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_DPthoO-IEeWLlrwIF3w0vA" base_Class="_DOEi4O-IEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_PMwrAO-fEeWLlrwIF3w0vA" base_Class="_PK97QO-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_kJjOAu-fEeWLlrwIF3w0vA" base_Class="_kJjOAO-fEeWLlrwIF3w0vA"/>
+  <OpenModel_Profile:OpenModelClass xmi:id="_rBq8Yu-fEeWLlrwIF3w0vA" base_Class="_rBq8YO-fEeWLlrwIF3w0vA"/>
 </xmi:XMI>


### PR DESCRIPTION
- Renamed the base package TapiModule to Tapi
- Removed Tapi:: prefix for ObjectClasses and DataTypes
- Moved up the Tapi StatePac classes to ObjectClasses
- Refactored ConnectivityConstraint, PathOptimizationConstraint, PathObjectiveFunction and ScheduleInfo to Class from DataType
- Renamed GlobalComponent and LocalComponent to GlobalClass and
LocalCLass
- Added the Generalization associations to Context, Topology, Node,
Link, ConnectivityService, Connection, NodeEdgePoint, ServiceEndPoint,
ConnectionEndPoint, Path
- Added StrictComposition associations to StatePacss